### PR TITLE
Multi-language runtimes + multi-tenant auth, per-user isolation, caps, and hardening

### DIFF
--- a/api.py
+++ b/api.py
@@ -7,7 +7,20 @@ import uvicorn
 import os
 
 # Import all routers
-from routers import containers, execution, jobs, webhooks, services, environment, logs, webhook_execution, proxy, workers
+from routers import (
+    auth as auth_router,
+    containers,
+    environment,
+    execution,
+    jobs,
+    logs,
+    proxy,
+    services,
+    users as users_router,
+    webhook_execution,
+    webhooks,
+    workers,
+)
 
 # Import services and models for startup
 from services.service_manager import service_manager
@@ -78,6 +91,12 @@ and injected into the user subprocess at execution time.
 """
 
 TAG_METADATA = [
+    {"name": "auth",
+     "description": "Log in, log out, introspect the current session."},
+    {"name": "users",
+     "description": "CRUD for users and API keys. Non-admins can manage "
+                    "their own keys via `/users/me/keys`; admins can "
+                    "manage every user via `/admin/users`."},
     {"name": "execution",
      "description": "Run code on demand and introspect the available runtimes."},
     {"name": "scheduled-jobs",
@@ -127,13 +146,43 @@ app = FastAPI(
     contact={"name": "supakiln", "url": "https://github.com/Frohrer/supakiln"},
 )
 
-# Add CORS middleware with permissive settings since Cloudflare bypasses OPTIONS to origin
+# CORS.
+#
+# With `allow_credentials=True`, browsers require Access-Control-Allow-
+# Origin to echo a specific origin — the `*` shortcut is rejected. So
+# we compute a concrete list: the env-provided ALLOWED_ORIGINS plus
+# localhost dev defaults. The `allow_origin_regex` fallback handles
+# ephemeral origins (Cloudflare preview URLs, etc.) when ENVIRONMENT
+# is not `production`.
+_allowed_origins_env = os.environ.get("ALLOWED_ORIGINS", "").strip()
+_allowed_origins = (
+    [o.strip() for o in _allowed_origins_env.split(",") if o.strip()]
+    if _allowed_origins_env
+    else []
+)
+# Always allow the common dev origins so docker-compose works out of the box.
+for dev_origin in (
+    "http://localhost:3000",
+    "http://127.0.0.1:3000",
+    "http://localhost:8000",
+    "http://127.0.0.1:8000",
+):
+    if dev_origin not in _allowed_origins:
+        _allowed_origins.append(dev_origin)
+
+_allow_origin_regex = None
+if os.environ.get("ENVIRONMENT", "").lower() != "production":
+    # In dev, accept any localhost / 127.* port so ad-hoc vite servers
+    # or preview builds also work.
+    _allow_origin_regex = r"^https?://(localhost|127\.0\.0\.1)(:\d+)?$"
+
 app.add_middleware(
     CORSMiddleware,
-    allow_origins=["*"],  # Allow all origins since Cloudflare handles the actual filtering
+    allow_origins=_allowed_origins,
+    allow_origin_regex=_allow_origin_regex,
     allow_credentials=True,
-    allow_methods=["*"],  # Allow all methods
-    allow_headers=["*"],  # Allow all headers
+    allow_methods=["*"],
+    allow_headers=["*"],
     max_age=86400,  # Cache preflight requests for 24 hours
 )
 
@@ -157,6 +206,8 @@ async def read_root():
     return FileResponse("static/index.html")
 
 # Include all routers
+app.include_router(auth_router.router)
+app.include_router(users_router.router)
 app.include_router(containers.router)
 app.include_router(execution.router)
 app.include_router(jobs.router)
@@ -201,6 +252,15 @@ async def startup_event():
     if not migration_success:
         print("💥 Database migration failed. Application cannot start safely.")
         sys.exit(1)
+
+    # Create the admin user from SUPAKILN_BOOTSTRAP_ADMIN_EMAIL /
+    # _PASSWORD if set and no admin exists yet. Runs after migrations
+    # so the users table is guaranteed to exist.
+    try:
+        from auth import bootstrap_admin
+        bootstrap_admin()
+    except Exception as e:
+        print(f"⚠️ Admin bootstrap failed (non-fatal): {e}")
 
     # Clean up orphaned containers from previous runs/crashes
     try:

--- a/api.py
+++ b/api.py
@@ -13,7 +13,119 @@ from routers import containers, execution, jobs, webhooks, services, environment
 from services.service_manager import service_manager
 from models import SessionLocal, PersistentService
 
-app = FastAPI(title="Code Execution Engine API")
+
+API_DESCRIPTION = """
+Self-hosted, multi-language code execution platform. Run user-submitted
+Python, Node.js, Ruby, Bash, or Go in isolated Docker containers with
+package installation, scheduled jobs, webhook endpoints, and long-running
+web services.
+
+## Execution models
+
+| Model | Entry point | Use case |
+|---|---|---|
+| **Ad-hoc** | `POST /execute` | Run a snippet and get stdout/stderr back |
+| **Scheduled** | `POST /jobs` | Cron-triggered code |
+| **Webhook** | `POST /webhook-jobs` → `POST /webhook/{path}` | Run on HTTP request |
+| **Persistent service** | `POST /services` | Streamlit / FastAPI / Flask / Dash / Gradio (Python only) |
+
+## Runtimes
+
+Call `GET /languages` for the authoritative list and capabilities.
+The default is `python`; specify `language` on any execution request to
+pick another.
+
+| Name | Package manager | Notes |
+|---|---|---|
+| `python` | pip | Streamlit/FastAPI/Flask/Dash/Gradio web-service detection |
+| `node` | npm | Node.js 20, global `fetch` available |
+| `ruby` | gem | — |
+| `bash` | (none) | `curl` and `jq` preinstalled |
+| `go` | (none) | stdlib only — dependency support is a follow-up |
+
+## Worker lifecycle
+
+Ad-hoc execution goes through a per-language HTTP worker container cached
+per (language, package set). First call for a given cache key is cold
+(image build + container create); subsequent calls are warm (~10-30ms
+for interpreted languages). Use the `/workers` endpoints to list, evict,
+or reset the cache. Idle workers are reaped automatically — see the
+`SUPAKILN_WORKER_IDLE_TTL_SECONDS` environment variable.
+
+## Request shape for execution
+
+```json
+{
+  "code": "print('hello')",
+  "language": "python",
+  "packages": ["requests"],
+  "timeout": 30
+}
+```
+
+The response includes `output`, `error`, `container_id`, `timed_out`, and
+a `timings_ms` breakdown (per-phase timing, useful for diagnosing cold
+vs. warm paths).
+
+## Isolation and limits
+
+Every worker container runs as UID 1000 with ALL capabilities dropped,
+512MB memory, 50% CPU quota, 100 PID limit. `/tmp` is a 128MB tmpfs
+mounted `noexec` so user code can't store and run arbitrary binaries
+there (Go is configured to compile outside `/tmp` for this reason).
+Environment variables (managed via `/env`) are Fernet-encrypted at rest
+and injected into the user subprocess at execution time.
+"""
+
+TAG_METADATA = [
+    {"name": "execution",
+     "description": "Run code on demand and introspect the available runtimes."},
+    {"name": "scheduled-jobs",
+     "description": "Cron-triggered jobs. Each job stores its code, packages, "
+                    "timeout, and target `language`."},
+    {"name": "webhook-jobs",
+     "description": "CRUD for webhook endpoints. The endpoint itself is served "
+                    "under the `webhook-execution` tag."},
+    {"name": "webhook-execution",
+     "description": "Dynamic `/webhook/{path}` endpoints that resolve to a "
+                    "configured webhook job and execute its code. Python jobs "
+                    "get `request_data`/`response_data` auto-wrapping; other "
+                    "languages receive request data via the "
+                    "`SUPAKILN_REQUEST_DATA` env var and must emit a JSON "
+                    "response on stdout."},
+    {"name": "persistent-services",
+     "description": "Long-running web apps (Streamlit, FastAPI, Flask, Dash, "
+                    "Gradio). Python-only today — uses the legacy container "
+                    "pipeline, not the worker path."},
+    {"name": "workers",
+     "description": "Lifecycle for ad-hoc worker containers cached by "
+                    "`/execute`. List what's alive, force-stop one, or reset "
+                    "the whole cache."},
+    {"name": "containers",
+     "description": "Legacy named-container CRUD, used by the frontend's "
+                    "'saved containers' flow. The worker path's cache is "
+                    "managed via the `workers` endpoints instead."},
+    {"name": "environment",
+     "description": "Fernet-encrypted environment variables injected into "
+                    "every execution."},
+    {"name": "logs",
+     "description": "History of execution results (ad-hoc, scheduled, webhook, "
+                    "service). Retained for 30 days."},
+    {"name": "proxy",
+     "description": "Reverse-proxy for running web services. `/proxy/{short_id}"
+                    "/...` forwards to the container's published port."},
+    {"name": "system",
+     "description": "Health check, root, static files."},
+]
+
+
+app = FastAPI(
+    title="supakiln",
+    version="0.2.0",
+    description=API_DESCRIPTION,
+    openapi_tags=TAG_METADATA,
+    contact={"name": "supakiln", "url": "https://github.com/Frohrer/supakiln"},
+)
 
 # Add CORS middleware with permissive settings since Cloudflare bypasses OPTIONS to origin
 app.add_middleware(
@@ -26,11 +138,12 @@ app.add_middleware(
 )
 
 # Add a health check endpoint that bypasses Cloudflare Access
-@app.get("/health")
+@app.get("/health", tags=["system"], summary="Health check")
 async def health_check():
-    """
-    Health check endpoint that should bypass Cloudflare Access.
-    Configure this endpoint to be public in your Cloudflare Access rules.
+    """Liveness probe. Returns 200 once the app has started.
+
+    Designed to bypass Cloudflare Access — configure this path as public
+    in your Access rules so uptime checks don't need auth.
     """
     return {"status": "healthy", "timestamp": datetime.utcnow().isoformat()}
 
@@ -38,9 +151,9 @@ async def health_check():
 static_dir = os.path.join(os.path.dirname(__file__), "static")
 app.mount("/static", StaticFiles(directory=static_dir), name="static")
 
-@app.get("/")
+@app.get("/", tags=["system"], summary="Serve the frontend shell", include_in_schema=False)
 async def read_root():
-    """Serve the main page."""
+    """Serves the frontend's index.html. Excluded from the OpenAPI schema."""
     return FileResponse("static/index.html")
 
 # Include all routers

--- a/api.py
+++ b/api.py
@@ -7,7 +7,7 @@ import uvicorn
 import os
 
 # Import all routers
-from routers import containers, execution, jobs, webhooks, services, environment, logs, webhook_execution, proxy
+from routers import containers, execution, jobs, webhooks, services, environment, logs, webhook_execution, proxy, workers
 
 # Import services and models for startup
 from services.service_manager import service_manager
@@ -53,6 +53,7 @@ app.include_router(environment.router)
 app.include_router(logs.router)
 app.include_router(webhook_execution.router)
 app.include_router(proxy.router)
+app.include_router(workers.router)
 
 async def startup_event():
     """Initialize services on startup."""

--- a/auth/__init__.py
+++ b/auth/__init__.py
@@ -1,0 +1,42 @@
+"""Authentication and authorization primitives.
+
+All auth state lives in two tables (see db_models.py):
+
+  users      — id, email, password_hash, is_admin, disabled.
+  api_keys   — id, user_id, hashed_key (sha256 hex of plaintext), prefix,
+               kind ('api' or 'session'), expires_at.
+
+Request authentication accepts either:
+  - `Authorization: Bearer <plaintext-token>` header, or
+  - `supakiln_session=<plaintext-token>` cookie.
+
+Both map to the same api_keys table; sessions just have a kind='session'
+and an expires_at. The plaintext is never stored; lookups always hash
+first and match on `hashed_key`.
+
+Transition mode: while SUPAKILN_ALLOW_ANONYMOUS=true (default), a request
+without credentials is attributed to the system user (id=1). Once you're
+ready to require auth for everyone, set SUPAKILN_ALLOW_ANONYMOUS=false
+and anonymous requests return 401.
+"""
+
+from auth.passwords import hash_password, verify_password
+from auth.tokens import (
+    generate_token,
+    hash_token,
+    SESSION_TTL_SECONDS,
+)
+from auth.deps import current_user, require_admin, get_or_create_system_user
+from auth.bootstrap import bootstrap_admin
+
+__all__ = [
+    "hash_password",
+    "verify_password",
+    "generate_token",
+    "hash_token",
+    "SESSION_TTL_SECONDS",
+    "current_user",
+    "require_admin",
+    "get_or_create_system_user",
+    "bootstrap_admin",
+]

--- a/auth/bootstrap.py
+++ b/auth/bootstrap.py
@@ -1,0 +1,56 @@
+"""Create the first admin user from env so operators can actually log in.
+
+Runs at startup after migrations. If SUPAKILN_BOOTSTRAP_ADMIN_EMAIL /
+SUPAKILN_BOOTSTRAP_ADMIN_PASSWORD are set and no admin exists yet, we
+create that admin. If an admin already exists, we leave it alone —
+operators can rotate the password via the /users API or directly in
+the DB.
+"""
+
+from __future__ import annotations
+
+import os
+
+from db_models import SessionLocal, User
+from auth.passwords import hash_password
+
+
+def bootstrap_admin() -> None:
+    email = os.environ.get("SUPAKILN_BOOTSTRAP_ADMIN_EMAIL")
+    password = os.environ.get("SUPAKILN_BOOTSTRAP_ADMIN_PASSWORD")
+    if not email or not password:
+        return
+
+    db = SessionLocal()
+    try:
+        existing_admin = (
+            db.query(User)
+            .filter(User.is_admin == 1, User.disabled == 0)
+            .first()
+        )
+        if existing_admin is not None:
+            print(f"✅ Admin already exists ({existing_admin.email}), "
+                  f"skipping bootstrap")
+            return
+
+        existing = db.query(User).filter(User.email == email).first()
+        if existing is not None:
+            existing.is_admin = 1
+            existing.disabled = 0
+            if password:
+                existing.password_hash = hash_password(password)
+            db.commit()
+            print(f"✅ Promoted existing user {email} to admin")
+            return
+
+        admin = User(
+            email=email,
+            password_hash=hash_password(password),
+            is_admin=1,
+            disabled=0,
+        )
+        db.add(admin)
+        db.commit()
+        print(f"✅ Bootstrapped admin user {email}")
+    finally:
+        db.close()

--- a/auth/deps.py
+++ b/auth/deps.py
@@ -1,0 +1,131 @@
+"""FastAPI dependencies: resolve the caller to a User row.
+
+Two entry points:
+
+  current_user    — accepts Bearer header / session cookie, falls back
+                    to the system user when SUPAKILN_ALLOW_ANONYMOUS is
+                    on. Returns a User.
+  require_admin   — same resolution, but rejects non-admins with 403.
+
+Keep these cheap: one indexed SELECT on `hashed_key`, one SELECT on
+`users`. A token's `last_used_at` is bumped at most once per N seconds
+to avoid hammering the DB on the hot path.
+"""
+
+from __future__ import annotations
+
+import os
+import threading
+import time
+from datetime import datetime
+from typing import Optional
+
+from fastapi import Depends, HTTPException, Request, status
+from sqlalchemy.orm import Session
+
+from database import get_db
+from db_models import ApiKey, User, SYSTEM_USER_ID
+from auth.tokens import hash_token
+
+
+def _allow_anonymous() -> bool:
+    return os.environ.get("SUPAKILN_ALLOW_ANONYMOUS", "true").lower() != "false"
+
+
+# Throttle `last_used_at` updates. 60s is fine-grained enough for
+# audit/UX and keeps us off the DB write path on tight hot loops.
+_LAST_USED_THROTTLE_SECONDS = 60
+_last_used_cache: dict = {}
+_last_used_lock = threading.Lock()
+
+
+def _maybe_bump_last_used(db: Session, key: ApiKey) -> None:
+    now = time.time()
+    with _last_used_lock:
+        prev = _last_used_cache.get(key.id, 0.0)
+        if now - prev < _LAST_USED_THROTTLE_SECONDS:
+            return
+        _last_used_cache[key.id] = now
+    key.last_used_at = datetime.utcnow()
+    db.commit()
+
+
+def _extract_token(request: Request) -> Optional[str]:
+    auth = request.headers.get("Authorization") or ""
+    if auth.lower().startswith("bearer "):
+        return auth[7:].strip() or None
+    cookie = request.cookies.get("supakiln_session")
+    if cookie:
+        return cookie
+    return None
+
+
+def get_or_create_system_user(db: Session) -> User:
+    user = db.query(User).filter(User.id == SYSTEM_USER_ID).first()
+    if user is not None:
+        return user
+    # Migration is supposed to seed id=1; if it didn't, create it now
+    # so anonymous fallback still works.
+    user = User(
+        id=SYSTEM_USER_ID,
+        email="system@supakiln.local",
+        password_hash=None,
+        is_admin=0,
+        disabled=0,
+    )
+    db.add(user)
+    db.commit()
+    db.refresh(user)
+    return user
+
+
+def current_user(
+    request: Request,
+    db: Session = Depends(get_db),
+) -> User:
+    token = _extract_token(request)
+
+    if token is None:
+        if _allow_anonymous():
+            return get_or_create_system_user(db)
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail="missing bearer token",
+            headers={"WWW-Authenticate": "Bearer"},
+        )
+
+    hashed = hash_token(token)
+    key = (
+        db.query(ApiKey)
+        .filter(ApiKey.hashed_key == hashed, ApiKey.revoked_at.is_(None))
+        .first()
+    )
+    if key is None:
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail="invalid token",
+        )
+    if key.expires_at is not None and key.expires_at < datetime.utcnow():
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail="token expired",
+        )
+
+    user = db.query(User).filter(User.id == key.user_id).first()
+    if user is None or user.disabled:
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail="user not available",
+        )
+
+    _maybe_bump_last_used(db, key)
+    return user
+
+
+def require_admin(user: User = Depends(current_user)) -> User:
+    if not user.is_admin:
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail="admin only",
+        )
+    return user

--- a/auth/passwords.py
+++ b/auth/passwords.py
@@ -1,0 +1,26 @@
+"""Password hashing with argon2id.
+
+argon2-cffi's PasswordHasher picks the OWASP-recommended parameters by
+default; we don't override them. `verify` throws on mismatch/invalid
+hash, so we wrap it to a bool.
+"""
+
+from __future__ import annotations
+
+from argon2 import PasswordHasher
+from argon2.exceptions import VerifyMismatchError, InvalidHash
+
+
+_hasher = PasswordHasher()
+
+
+def hash_password(plaintext: str) -> str:
+    return _hasher.hash(plaintext)
+
+
+def verify_password(hashed: str, plaintext: str) -> bool:
+    try:
+        _hasher.verify(hashed, plaintext)
+        return True
+    except (VerifyMismatchError, InvalidHash):
+        return False

--- a/auth/tokens.py
+++ b/auth/tokens.py
@@ -1,0 +1,39 @@
+"""Opaque bearer tokens for both API keys and sessions.
+
+Format: "supa_<base64url(32 random bytes)>". 43 chars of entropy after
+the prefix; URL-safe, no padding.
+
+At rest we store sha256(plaintext) as hex (64 chars). Lookups hash the
+incoming token first, so the plaintext only ever lives in the user's
+client and in memory during one request.
+
+The `prefix` column stores the first 12 chars of the plaintext (the
+"supa_" tag + 7 id chars) so UIs can show "supa_ABC1234…" in a list
+without revealing the rest.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import secrets
+from typing import Tuple
+
+
+TOKEN_PREFIX = "supa_"
+_RANDOM_BYTES = 32
+_PREFIX_LEN = 12  # "supa_" + 7 chars
+
+# 14-day session token TTL. API keys are long-lived (no TTL).
+SESSION_TTL_SECONDS = 60 * 60 * 24 * 14
+
+
+def generate_token() -> Tuple[str, str, str]:
+    """Return (plaintext, hashed_hex, prefix_for_display)."""
+    plaintext = TOKEN_PREFIX + secrets.token_urlsafe(_RANDOM_BYTES)
+    hashed = hash_token(plaintext)
+    prefix = plaintext[:_PREFIX_LEN]
+    return plaintext, hashed, prefix
+
+
+def hash_token(plaintext: str) -> str:
+    return hashlib.sha256(plaintext.encode("utf-8")).hexdigest()

--- a/bench/README.md
+++ b/bench/README.md
@@ -1,0 +1,48 @@
+# Benchmarks
+
+`bench_executor.py` attributes end-to-end execution latency across:
+
+- `execute_code` total (direct mode) or `POST /execute` total (http mode)
+- Internal phases reported by `CodeExecutor` (package_hash, detect_web_service, base64 encode, `exec_run`, etc.)
+- Raw `docker exec /bin/true` (pure namespace-entry cost) and `docker exec python3 -c pass` (exec + interpreter cold start) against the same cached container
+- A derived "python3 cold start" figure (py_pass − /bin/true)
+- A derived "network + FastAPI + DB-log" figure (http total − server total)
+
+## Prerequisites
+
+`docker-compose up` (or `docker-compose -f docker-compose.dev.yml up`) with backend and docker-daemon services healthy.
+
+## Run it
+
+The `direct` mode must run where `DOCKER_HOST` points at the dind sidecar — easiest is to exec into the backend container:
+
+```bash
+docker-compose exec backend python bench/bench_executor.py direct --iters 30
+```
+
+The `http` mode can run from anywhere that can reach the API:
+
+```bash
+# from host
+python bench/bench_executor.py http --iters 30 --url http://localhost:8000
+
+# or from inside the backend container
+docker-compose exec backend python bench/bench_executor.py http --iters 30 --url http://localhost:8000
+```
+
+## Reading the output
+
+Each row reports `min / p50 / p90 / p99 / max / mean` in milliseconds over N iterations.
+
+Key rows:
+
+- **`execute_code total`** — what a caller sees (minus FastAPI overhead)
+- **`phase exec_run_ms`** — time for the `container.exec_run()` call: this is `docker exec` round-trip + interpreter cold start + user code
+- **`phase containers_get_ms`** — docker-py SDK `containers.get()`; should be single-digit ms
+- **`phase detect_web_service_ms`** — called unconditionally; currently does a socket-bind port allocation even when the code isn't a web service (suspected waste)
+- **`raw docker exec /bin/true`** — pure namespace entry; the floor for any `docker exec` approach
+- **`derived 'python3 cold start'`** — the cost we'd eliminate with a persistent worker
+
+If `derived 'python3 cold start'` is a large fraction of `execute_code total`, a persistent-worker architecture is the right next step. If `raw /bin/true` alone is already >100ms, we need to skip `docker exec` entirely (e.g. talk to a socket inside the container).
+
+Paste the output back and we'll pick the optimization.

--- a/bench/_mkpayload.py
+++ b/bench/_mkpayload.py
@@ -1,0 +1,2 @@
+import json, sys
+print(json.dumps({"code": sys.argv[1], "language": "bash", "timeout": int(sys.argv[2])}))

--- a/bench/_pretty.py
+++ b/bench/_pretty.py
@@ -1,0 +1,9 @@
+import json, sys
+r = json.load(sys.stdin)
+print("---OUTPUT---")
+print(r.get("output") or "")
+print("---ERROR---")
+print(r.get("error") or "")
+cid = (r.get("container_id") or "?")[:12]
+ch = r.get("timings_ms", {}).get("container_cache_hit")
+print(f"---META container={cid} ok={r.get('success')} cache_hit={ch} timed_out={r.get('timed_out')}---")

--- a/bench/bench_executor.py
+++ b/bench/bench_executor.py
@@ -1,0 +1,237 @@
+"""Latency profiler for supakiln code execution.
+
+Two modes:
+
+  direct   Instantiates CodeExecutor in-process and drives execute_code
+           directly. Must run where DOCKER_HOST points at the daemon that
+           hosts user containers (i.e. inside the `backend` service in
+           docker-compose, or with DOCKER_HOST set to the dind sidecar).
+
+  http     Hits POST /execute over HTTP. Measures the full API round-trip
+           (FastAPI + executor + logging). The server must be running.
+
+Both modes run a warmup, then N timed iterations of a trivial payload, and
+additionally probe raw `docker exec /bin/true` + `docker exec python3 -c 'pass'`
+against the same container so we can separate namespace-entry cost from
+interpreter cold start.
+
+Usage:
+    python bench/bench_executor.py direct --iters 30
+    python bench/bench_executor.py http   --iters 30 --url http://localhost:8000
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import statistics
+import subprocess
+import sys
+import time
+from time import perf_counter
+from typing import Callable, Dict, List, Optional
+
+
+REPO_ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+if REPO_ROOT not in sys.path:
+    sys.path.insert(0, REPO_ROOT)
+
+
+def pct(values: List[float], p: float) -> float:
+    if not values:
+        return float("nan")
+    ordered = sorted(values)
+    k = (len(ordered) - 1) * p
+    lo = int(k)
+    hi = min(lo + 1, len(ordered) - 1)
+    frac = k - lo
+    return ordered[lo] + (ordered[hi] - ordered[lo]) * frac
+
+
+def summarize(name: str, samples: List[float]) -> Dict[str, float]:
+    if not samples:
+        return {"name": name, "n": 0}
+    return {
+        "name": name,
+        "n": len(samples),
+        "min": min(samples),
+        "p50": pct(samples, 0.50),
+        "p90": pct(samples, 0.90),
+        "p99": pct(samples, 0.99),
+        "max": max(samples),
+        "mean": statistics.fmean(samples),
+    }
+
+
+def print_table(rows: List[Dict[str, float]]) -> None:
+    if not rows:
+        print("(no samples)")
+        return
+    cols = ["name", "n", "min", "p50", "p90", "p99", "max", "mean"]
+    widths = {c: max(len(c), max(len(_fmt(r.get(c))) for r in rows)) for c in cols}
+    header = "  ".join(c.ljust(widths[c]) for c in cols)
+    print(header)
+    print("  ".join("-" * widths[c] for c in cols))
+    for r in rows:
+        print("  ".join(_fmt(r.get(c)).ljust(widths[c]) for c in cols))
+
+
+def _fmt(v) -> str:
+    if v is None:
+        return ""
+    if isinstance(v, float):
+        return f"{v:.2f}"
+    return str(v)
+
+
+def collect_phase_samples(phase_traces: List[Dict[str, float]]) -> Dict[str, List[float]]:
+    """Transpose list-of-dicts into dict-of-lists, dropping None."""
+    out: Dict[str, List[float]] = {}
+    for trace in phase_traces:
+        for k, v in trace.items():
+            if v is None:
+                continue
+            out.setdefault(k, []).append(float(v))
+    return out
+
+
+def run_direct(iters: int) -> None:
+    """Drive CodeExecutor in-process. Must have access to the user-container daemon."""
+    from code_executor import CodeExecutor
+
+    executor = CodeExecutor()
+
+    # Warmup: first call builds image + creates container. Not timed.
+    print("[direct] warming up (build image + create container)...", flush=True)
+    warm = executor.execute_code("pass", [], timeout=30)
+    if not warm.get("success"):
+        print(f"[direct] warmup failed: {warm.get('error')}")
+        executor.cleanup()
+        return
+    container_id = warm.get("container_id")
+    print(f"[direct] warm container: {container_id[:12] if container_id else '?'}")
+
+    # Timed iterations, trivial payload.
+    totals: List[float] = []
+    phase_traces: List[Dict[str, float]] = []
+    for _ in range(iters):
+        t0 = perf_counter()
+        res = executor.execute_code("pass", [], timeout=30)
+        elapsed_ms = (perf_counter() - t0) * 1000
+        totals.append(elapsed_ms)
+        if "timings_ms" in res:
+            phase_traces.append(res["timings_ms"])
+
+    # Raw docker-exec probes against the same container.
+    raw_true: List[float] = []
+    raw_py_pass: List[float] = []
+    env = os.environ.copy()
+    for _ in range(iters):
+        t0 = perf_counter()
+        subprocess.run(
+            ["docker", "exec", container_id, "/bin/true"],
+            capture_output=True, env=env, check=False,
+        )
+        raw_true.append((perf_counter() - t0) * 1000)
+
+        t0 = perf_counter()
+        subprocess.run(
+            ["docker", "exec", container_id, "python3", "-c", "pass"],
+            capture_output=True, env=env, check=False,
+        )
+        raw_py_pass.append((perf_counter() - t0) * 1000)
+
+    # Report.
+    print()
+    print("=== direct mode ===")
+    rows = [summarize("execute_code total (ms)", totals)]
+    rows += [
+        summarize(f"  phase {k} (ms)", v)
+        for k, v in collect_phase_samples(phase_traces).items()
+    ]
+    rows += [
+        summarize("raw docker exec /bin/true (ms)", raw_true),
+        summarize("raw docker exec python3 -c pass (ms)", raw_py_pass),
+    ]
+    print_table(rows)
+
+    # Diagnostic: derived interpreter cold-start = py_pass - true
+    if raw_true and raw_py_pass:
+        delta = [py - tr for py, tr in zip(raw_py_pass, raw_true)]
+        print()
+        print("derived 'python3 cold start' (py_pass - /bin/true):")
+        print_table([summarize("delta (ms)", delta)])
+
+    executor.cleanup()
+
+
+def run_http(iters: int, url: str) -> None:
+    import urllib.request
+    import urllib.error
+
+    endpoint = url.rstrip("/") + "/execute"
+    payload = json.dumps({"code": "pass", "packages": []}).encode()
+    headers = {"Content-Type": "application/json"}
+
+    def call() -> tuple[float, Optional[Dict]]:
+        req = urllib.request.Request(endpoint, data=payload, headers=headers, method="POST")
+        t0 = perf_counter()
+        try:
+            with urllib.request.urlopen(req, timeout=60) as resp:
+                body = resp.read()
+        except urllib.error.HTTPError as e:
+            body = e.read()
+        elapsed_ms = (perf_counter() - t0) * 1000
+        try:
+            return elapsed_ms, json.loads(body)
+        except json.JSONDecodeError:
+            return elapsed_ms, None
+
+    print(f"[http] warming up against {endpoint}...", flush=True)
+    _, warm = call()
+    if warm and not warm.get("success"):
+        print(f"[http] warmup non-success: {warm.get('error')}")
+
+    totals: List[float] = []
+    phase_traces: List[Dict[str, float]] = []
+    for _ in range(iters):
+        ms, body = call()
+        totals.append(ms)
+        if body and "timings_ms" in body:
+            phase_traces.append(body["timings_ms"])
+
+    print()
+    print("=== http mode ===")
+    rows = [summarize("POST /execute total (ms)", totals)]
+    rows += [
+        summarize(f"  phase {k} (ms)", v)
+        for k, v in collect_phase_samples(phase_traces).items()
+    ]
+    print_table(rows)
+
+    # If we got server-side totals, the delta is network + FastAPI + logging overhead.
+    if phase_traces:
+        server_total = [t.get("total_ms") for t in phase_traces if t.get("total_ms") is not None]
+        if server_total and len(server_total) == len(totals):
+            overhead = [c - s for c, s in zip(totals, server_total)]
+            print()
+            print("derived 'network + FastAPI + DB-log' overhead (client - server total):")
+            print_table([summarize("delta (ms)", overhead)])
+
+
+def main() -> None:
+    ap = argparse.ArgumentParser()
+    ap.add_argument("mode", choices=["direct", "http"])
+    ap.add_argument("--iters", type=int, default=30)
+    ap.add_argument("--url", default="http://localhost:8000")
+    args = ap.parse_args()
+
+    if args.mode == "direct":
+        run_direct(args.iters)
+    else:
+        run_http(args.iters, args.url)
+
+
+if __name__ == "__main__":
+    main()

--- a/bench/e2e_auth_caps.sh
+++ b/bench/e2e_auth_caps.sh
@@ -1,0 +1,172 @@
+#!/bin/bash
+# End-to-end smoke test for steps 1-3: auth, per-user containers, caps+eviction.
+#
+# Prerequisites:
+#   - backend running on :8000
+#   - admin@supakiln.local / ChangeMe123 exists (bootstrapped from env)
+#   - MAX_WORKERS_PER_USER small (default 5) — for cap test, set to 2:
+#       SUPAKILN_MAX_WORKERS_PER_USER=2 docker compose up -d backend
+#
+# Runs every assertion as `expect=<actual>`; exits non-zero if anything is off.
+
+set -u
+BASE=http://localhost:8000
+FAIL=0
+
+say() { printf '\n\033[1;36m▶ %s\033[0m\n' "$*"; }
+ok()  { printf '  \033[0;32m✓\033[0m %s\n' "$*"; }
+fail() { printf '  \033[0;31m✗\033[0m %s\n' "$*"; FAIL=$((FAIL+1)); }
+
+jq_get() { python -c "import json,sys; print(json.load(sys.stdin).get('$1',''))"; }
+
+# ------------ step 1: auth ------------
+say "Step 1 — login as admin"
+ADMIN_RESP=$(curl -sS -X POST $BASE/auth/login -H 'Content-Type: application/json' \
+  -d '{"email":"admin@supakiln.local","password":"ChangeMe123"}')
+ADMIN=$(echo "$ADMIN_RESP" | jq_get session_token)
+[ -n "$ADMIN" ] && ok "admin session token obtained" || fail "admin login failed: $ADMIN_RESP"
+
+say "Step 1 — wrong password rejected"
+CODE=$(curl -sS -o /dev/null -w "%{http_code}" -X POST $BASE/auth/login \
+  -H 'Content-Type: application/json' \
+  -d '{"email":"admin@supakiln.local","password":"wrong"}')
+[ "$CODE" = "401" ] && ok "wrong password → 401" || fail "wrong password → $CODE (expected 401)"
+
+say "Step 1 — /auth/me resolves bearer token"
+ME=$(curl -sS $BASE/auth/me -H "Authorization: Bearer $ADMIN")
+IS_ADMIN=$(echo "$ME" | jq_get is_admin)
+[ "$IS_ADMIN" = "True" ] && ok "/auth/me says is_admin=True" || fail "/auth/me: $ME"
+
+say "Step 1 — create fresh test users alice+bob"
+curl -sS -o /dev/null -X POST $BASE/admin/users -H "Authorization: Bearer $ADMIN" \
+  -H 'Content-Type: application/json' \
+  -d '{"email":"e2e-alice@example.com","password":"alicePW1"}'
+curl -sS -o /dev/null -X POST $BASE/admin/users -H "Authorization: Bearer $ADMIN" \
+  -H 'Content-Type: application/json' \
+  -d '{"email":"e2e-bob@example.com","password":"bobPW5678"}'
+ALICE=$(curl -sS -X POST $BASE/auth/login -H 'Content-Type: application/json' \
+  -d '{"email":"e2e-alice@example.com","password":"alicePW1"}' | jq_get session_token)
+BOB=$(curl -sS -X POST $BASE/auth/login -H 'Content-Type: application/json' \
+  -d '{"email":"e2e-bob@example.com","password":"bobPW5678"}' | jq_get session_token)
+[ -n "$ALICE" ] && [ -n "$BOB" ] && ok "alice+bob logged in" || fail "couldn't get tokens"
+
+say "Step 1 — alice mints + uses API key"
+KEYRESP=$(curl -sS -X POST $BASE/users/me/keys -H "Authorization: Bearer $ALICE" \
+  -H 'Content-Type: application/json' -d '{"label":"ci"}')
+KEY=$(echo "$KEYRESP" | jq_get token)
+[ -n "$KEY" ] && ok "key minted" || fail "key mint failed: $KEYRESP"
+EMAIL_VIA_KEY=$(curl -sS $BASE/auth/me -H "Authorization: Bearer $KEY" | jq_get email)
+[ "$EMAIL_VIA_KEY" = "e2e-alice@example.com" ] \
+  && ok "API key resolves to alice" \
+  || fail "API key resolved to: $EMAIL_VIA_KEY"
+
+say "Step 1 — alice can't reach /admin/users"
+CODE=$(curl -sS -o /dev/null -w "%{http_code}" $BASE/admin/users \
+  -H "Authorization: Bearer $ALICE")
+[ "$CODE" = "403" ] && ok "alice → /admin/users → 403" || fail "alice got $CODE"
+
+# ------------ step 2: per-user containers ------------
+say "Step 2 — reset workers, alice+bob each run bash"
+curl -sS -X POST $BASE/workers/reset -H "Authorization: Bearer $ADMIN" > /dev/null
+A_CID=$(curl -sS -X POST $BASE/execute -H "Authorization: Bearer $ALICE" \
+  -H 'Content-Type: application/json' \
+  -d '{"code":"echo alice","language":"bash","timeout":5}' | jq_get container_id)
+B_CID=$(curl -sS -X POST $BASE/execute -H "Authorization: Bearer $BOB" \
+  -H 'Content-Type: application/json' \
+  -d '{"code":"echo bob","language":"bash","timeout":5}' | jq_get container_id)
+[ -n "$A_CID" ] && [ -n "$B_CID" ] && [ "$A_CID" != "$B_CID" ] \
+  && ok "alice=${A_CID:0:12} bob=${B_CID:0:12} — different containers" \
+  || fail "same container: alice=$A_CID bob=$B_CID"
+
+say "Step 2 — env vars don't leak across users"
+curl -sS -o /dev/null -X POST $BASE/env -H "Authorization: Bearer $ALICE" \
+  -H 'Content-Type: application/json' -d '{"name":"LEAKTEST","value":"alice-val"}'
+curl -sS -o /dev/null -X POST $BASE/env -H "Authorization: Bearer $BOB" \
+  -H 'Content-Type: application/json' -d '{"name":"LEAKTEST","value":"bob-val"}'
+A_SEES=$(curl -sS -X POST $BASE/execute -H "Authorization: Bearer $ALICE" \
+  -H 'Content-Type: application/json' \
+  -d '{"code":"echo $LEAKTEST","language":"bash","timeout":5}' | jq_get output | tr -d '\r\n ')
+B_SEES=$(curl -sS -X POST $BASE/execute -H "Authorization: Bearer $BOB" \
+  -H 'Content-Type: application/json' \
+  -d '{"code":"echo $LEAKTEST","language":"bash","timeout":5}' | jq_get output | tr -d '\r\n ')
+[ "$A_SEES" = "alice-val" ] && [ "$B_SEES" = "bob-val" ] \
+  && ok "alice sees 'alice-val', bob sees 'bob-val'" \
+  || fail "alice=$A_SEES bob=$B_SEES"
+
+say "Step 2 — alice creates job, bob can't see it"
+JID=$(curl -sS -X POST $BASE/jobs -H "Authorization: Bearer $ALICE" \
+  -H 'Content-Type: application/json' \
+  -d '{"name":"alice-only","code":"print(1)","cron_expression":"0 0 1 1 0","language":"python"}' \
+  | jq_get id)
+BOB_CNT=$(curl -sS $BASE/jobs -H "Authorization: Bearer $BOB" \
+  | python -c "import json,sys; print(len(json.load(sys.stdin)))")
+CODE=$(curl -sS -o /dev/null -w "%{http_code}" "$BASE/jobs/$JID" \
+  -H "Authorization: Bearer $BOB")
+[ "$BOB_CNT" = "0" ] && [ "$CODE" = "404" ] \
+  && ok "bob sees 0 jobs, alice's job GET → 404 for bob" \
+  || fail "bob sees $BOB_CNT jobs, GET → $CODE"
+curl -sS -X DELETE "$BASE/jobs/$JID" -H "Authorization: Bearer $ALICE" > /dev/null
+
+# ------------ step 3: caps + eviction ------------
+say "Step 3 — checking per-user cap"
+MAX_USER=$(docker exec supakiln-backend-1 sh -c 'echo $SUPAKILN_MAX_WORKERS_PER_USER')
+echo "  MAX_WORKERS_PER_USER=$MAX_USER (run with =2 for a tight test)"
+
+say "Step 3 — warm alice's workers (bash+python)"
+curl -sS -X POST $BASE/workers/reset -H "Authorization: Bearer $ADMIN" > /dev/null
+curl -sS -X POST $BASE/execute -H "Authorization: Bearer $ALICE" \
+  -H 'Content-Type: application/json' -d '{"code":"echo","language":"bash"}' > /dev/null
+curl -sS -X POST $BASE/execute -H "Authorization: Bearer $ALICE" \
+  -H 'Content-Type: application/json' -d '{"code":"print(1)","language":"python"}' > /dev/null
+COUNT=$(curl -sS $BASE/workers -H "Authorization: Bearer $ALICE" \
+  | python -c "import json,sys; print(len(json.load(sys.stdin)['workers']))")
+[ "$COUNT" = "2" ] && ok "alice has 2 workers" || fail "alice has $COUNT workers"
+
+say "Step 3 — 3rd distinct cache key triggers LRU eviction (cap=2) or coexists (cap>=3)"
+THIRD=$(curl -sS -X POST $BASE/execute -H "Authorization: Bearer $ALICE" \
+  -H 'Content-Type: application/json' \
+  -d '{"code":"console.log(1)","language":"node"}' | jq_get container_id)
+[ -n "$THIRD" ] && ok "3rd (node) container=${THIRD:0:12} came up" || fail "3rd failed"
+AFTER=$(curl -sS $BASE/workers -H "Authorization: Bearer $ALICE" \
+  | python -c "import json,sys; print(len(json.load(sys.stdin)['workers']))")
+printf "  alice now has %s worker(s) (cap=%s — eviction iff cap < 3)\n" "$AFTER" "$MAX_USER"
+
+if [ "$MAX_USER" -le 2 ]; then
+  say "Step 3 — saturate both workers and try a 3rd → expect 429"
+  curl -sS -X POST $BASE/workers/reset -H "Authorization: Bearer $ALICE" > /dev/null
+  curl -sS -X POST $BASE/execute -H "Authorization: Bearer $ALICE" \
+    -H 'Content-Type: application/json' -d '{"code":"echo","language":"bash"}' > /dev/null
+  curl -sS -X POST $BASE/execute -H "Authorization: Bearer $ALICE" \
+    -H 'Content-Type: application/json' -d '{"code":"print(1)","language":"python"}' > /dev/null
+  (curl -sS -o /dev/null -X POST $BASE/execute -H "Authorization: Bearer $ALICE" \
+    -H 'Content-Type: application/json' \
+    -d '{"code":"sleep 6","language":"bash","timeout":10}') &
+  (curl -sS -o /dev/null -X POST $BASE/execute -H "Authorization: Bearer $ALICE" \
+    -H 'Content-Type: application/json' \
+    -d '{"code":"import time; time.sleep(6)","language":"python","timeout":10}') &
+  sleep 2
+  CODE=$(curl -sS -o /tmp/429.json -w "%{http_code}" -X POST $BASE/execute \
+    -H "Authorization: Bearer $ALICE" -H 'Content-Type: application/json' \
+    -d '{"code":"console.log(1)","language":"node","timeout":5}')
+  wait
+  [ "$CODE" = "429" ] && ok "3rd request → HTTP 429 (worker cap, all busy)" \
+    || fail "expected 429, got $CODE — body: $(cat /tmp/429.json)"
+else
+  echo "  (skipping 429 saturation test — cap is $MAX_USER; re-run with MAX_WORKERS_PER_USER=2)"
+fi
+
+say "Step 3 — pressure reaper sanity check"
+REAPED=$(docker logs --since=10m supakiln-backend-1 2>&1 \
+  | grep -E "Memory-pressure reaped|CPU-pressure reaped" | wc -l)
+echo "  pressure reap events in last 10min: $REAPED"
+ok "reaper is registered (check docker logs for activity under load)"
+
+# ------------ summary ------------
+echo
+if [ "$FAIL" = "0" ]; then
+  echo -e "\033[1;32m✔ ALL CHECKS PASSED\033[0m"
+  exit 0
+else
+  echo -e "\033[1;31m✘ $FAIL CHECK(S) FAILED\033[0m"
+  exit 1
+fi

--- a/bench/run_probe.sh
+++ b/bench/run_probe.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+# Run an authenticated bash /execute probe. Takes code on stdin.
+# Usage:  cat payload.sh | bench/run_probe.sh [timeout]
+# Requires admin creds in env (default: admin@supakiln.local / ChangeMe123).
+TO="${1:-15}"
+EMAIL="${SUPAKILN_ADMIN_EMAIL:-admin@supakiln.local}"
+PASS="${SUPAKILN_ADMIN_PASSWORD:-ChangeMe123}"
+DIR="$(dirname "$0")"
+TOKEN=$(curl -sS -X POST http://localhost:8000/auth/login -H 'Content-Type: application/json' \
+  -d "{\"email\":\"$EMAIL\",\"password\":\"$PASS\"}" \
+  | python -c "import json,sys; print(json.load(sys.stdin)['session_token'])")
+CODE=$(cat)
+# Build JSON body safely.
+python -c 'import json,sys; print(json.dumps({"code":sys.argv[1],"language":"bash","timeout":int(sys.argv[2])}))' "$CODE" "$TO" \
+  | curl -sS -X POST http://localhost:8000/execute \
+      -H "Authorization: Bearer $TOKEN" \
+      -H 'Content-Type: application/json' --data-binary @- \
+  | python "$DIR/_pretty.py"

--- a/bench/secprobe.sh
+++ b/bench/secprobe.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+# Helper: POST a bash payload, pretty-print output/error.
+# Usage: ./secprobe.sh "bash one-liner" [timeout_seconds]
+code="$1"
+to="${2:-15}"
+dir="$(dirname "$0")"
+payload=$(python "$dir/_mkpayload.py" "$code" "$to")
+curl -sS -X POST http://localhost:8000/execute \
+  -H 'Content-Type: application/json' \
+  -d "$payload" \
+  | python "$dir/_pretty.py"

--- a/code_executor.py
+++ b/code_executor.py
@@ -68,6 +68,10 @@ class CodeExecutor:
         self.worker_containers: Dict[str, str] = {}
         # Worker endpoints: container_id -> (host, port) to reach its HTTP API
         self.worker_endpoints: Dict[str, Tuple[str, int]] = {}
+        # Per-container metadata the lifecycle API surfaces: language,
+        # package_hash, cache_key, created_at, last_used. Updated on
+        # creation and on every /exec call.
+        self.worker_meta: Dict[str, Dict] = {}
         # HTTP session with connection pooling so each /exec POST reuses a
         # TCP connection to the worker when possible.
         self._http = requests.Session()
@@ -414,6 +418,7 @@ USER codeuser
             cur = self.worker_endpoints.get(container_id)
             if cur is not None:
                 self.worker_endpoints.pop(container_id, None)
+            self.worker_meta.pop(container_id, None)
             if self.containers.get(cache_key) == container_id:
                 self.containers.pop(cache_key, None)
             try:
@@ -507,6 +512,14 @@ USER codeuser
 
             self.worker_containers[cache_key] = container_id
             self.worker_endpoints[container_id] = (host, host_port)
+            now = time.time()
+            self.worker_meta[container_id] = {
+                "language": runtime.name,
+                "package_hash": package_hash,
+                "cache_key": cache_key,
+                "created_at": now,
+                "last_used": now,
+            }
             # Also register in the legacy `containers` dict so existing code
             # (debug endpoints, container_id lookups) still works.
             self.containers[cache_key] = container_id
@@ -1142,6 +1155,10 @@ export PYTHONPATH=/tmp:$PYTHONPATH
                     timings['worker_exec_ms'] = (perf_counter() - t_exec) * 1000
                     if attempt == 1:
                         timings['self_heal_recovered'] = 1.0
+                    # Record liveness for lifecycle + idle reaper.
+                    meta = self.worker_meta.get(container_id)
+                    if meta is not None:
+                        meta["last_used"] = time.time()
                     break
                 except WorkerUnreachableError as e:
                     last_unreachable = e
@@ -1195,6 +1212,76 @@ export PYTHONPATH=/tmp:$PYTHONPATH
         self.web_service_containers.clear()
         self.worker_containers.clear()
         self.worker_endpoints.clear()
+        self.worker_meta.clear()
+
+    # ------------------------------------------------------------------
+    # Lifecycle API used by the /workers router and the idle reaper.
+    # ------------------------------------------------------------------
+
+    def list_workers(self) -> List[Dict]:
+        """Return a snapshot of live ad-hoc workers."""
+        out: List[Dict] = []
+        for container_id, meta in list(self.worker_meta.items()):
+            endpoint = self.worker_endpoints.get(container_id)
+            out.append({
+                "container_id": container_id,
+                "language": meta["language"],
+                "package_hash": meta["package_hash"],
+                "cache_key": meta["cache_key"],
+                "created_at": meta["created_at"],
+                "last_used": meta["last_used"],
+                "host": endpoint[0] if endpoint else None,
+                "port": endpoint[1] if endpoint else None,
+            })
+        # Stable order for UIs.
+        out.sort(key=lambda w: (w["language"], w["created_at"]))
+        return out
+
+    def stop_worker(self, container_id: str) -> bool:
+        """Force-kill one worker. Returns True if it was tracked."""
+        meta = self.worker_meta.get(container_id)
+        if meta is None:
+            # Still try to kill the container in case it's a stale one we
+            # lost track of after a backend restart.
+            try:
+                subprocess.run(
+                    ["docker", "rm", "-f", container_id],
+                    capture_output=True, env=os.environ.copy(), timeout=15,
+                )
+            except Exception:
+                pass
+            return False
+        self._evict_worker(meta["cache_key"], container_id)
+        return True
+
+    def reset_workers(self) -> int:
+        """Stop and forget every tracked ad-hoc worker. Returns count killed."""
+        killed = 0
+        for container_id in list(self.worker_meta.keys()):
+            meta = self.worker_meta.get(container_id)
+            if meta is None:
+                continue
+            self._evict_worker(meta["cache_key"], container_id)
+            killed += 1
+        return killed
+
+    def reap_idle_workers(self, idle_ttl_seconds: float) -> List[str]:
+        """Stop workers whose last_used is older than idle_ttl_seconds.
+
+        Returns the list of container_ids that were reaped. idle_ttl <= 0
+        disables reaping (caller should skip invoking altogether in that
+        case, but we also guard here).
+        """
+        if idle_ttl_seconds <= 0:
+            return []
+        now = time.time()
+        cutoff = now - idle_ttl_seconds
+        reaped: List[str] = []
+        for container_id, meta in list(self.worker_meta.items()):
+            if meta["last_used"] < cutoff:
+                self._evict_worker(meta["cache_key"], container_id)
+                reaped.append(container_id)
+        return reaped
 
     def shutdown(self):
         """Graceful shutdown: stop and remove all tracked containers."""

--- a/code_executor.py
+++ b/code_executor.py
@@ -8,6 +8,7 @@ import base64
 import docker
 import random
 import logging
+from time import perf_counter
 from typing import Dict, List, Optional, Tuple
 from concurrent.futures import ThreadPoolExecutor, TimeoutError
 from services.docker_client import docker_client
@@ -345,27 +346,33 @@ USER codeuser
         
         return success and not timed_out, combined_output, combined_error, timed_out
     
-    def _execute_with_streaming_timeout_and_env(self, container_id: str, encoded_code: str, timeout: int, env_vars: Dict[str, str]) -> Tuple[bool, str, Optional[str], bool]:
+    def _execute_with_streaming_timeout_and_env(self, container_id: str, encoded_code: str, timeout: int, env_vars: Dict[str, str], timings: Optional[Dict[str, float]] = None) -> Tuple[bool, str, Optional[str], bool]:
         """Execute code in a container with environment variables injected at execution time."""
         import threading
         import docker
-        
+
         output_buffer = []
         error_buffer = []
         success = False
         timed_out = False
-        
+        # Shared timings dict so we can measure phases inside the worker thread
+        t = timings if timings is not None else {}
+
         def collect_output():
             nonlocal success, timed_out
             try:
+                t_get = perf_counter()
                 container = docker_client.containers.get(container_id)
+                t['containers_get_ms'] = (perf_counter() - t_get) * 1000
                 # Execute with environment variables injected at execution time
+                t_exec = perf_counter()
                 result = container.exec_run(
                     f"python3 -c 'import base64; exec(base64.b64decode(\"{encoded_code}\").decode())'",
                     environment=env_vars,  # Inject environment variables here
                     stream=False,  # Don't stream to get proper exit code
                     demux=True     # Separate stdout and stderr
                 )
+                t['exec_run_ms'] = (perf_counter() - t_exec) * 1000
                 
                 # Process the output
                 if result.output:
@@ -423,23 +430,30 @@ USER codeuser
     def execute_code(self, code: str, packages: List[str], timeout: int = 30, env_vars: Dict[str, str] = None) -> Dict:
         """
         Execute Python code in a container with the specified packages.
-        
+
         Args:
             code: Python code to execute
             packages: List of required Python packages
             timeout: Maximum execution time in seconds
             env_vars: Dictionary of environment variables to pass to the container
-            
+
         Returns:
             Dict containing execution results
         """
+        t_start = perf_counter()
+        timings: Dict[str, float] = {}
+
         if env_vars is None:
             env_vars = {}
-            
+
+        t_hash = perf_counter()
         package_hash = self._get_package_hash(packages)
-        
+        timings['package_hash_ms'] = (perf_counter() - t_hash) * 1000
+
         # Detect if this is a web service
+        t_detect = perf_counter()
         web_service = self._detect_web_service(code, packages)
+        timings['detect_web_service_ms'] = (perf_counter() - t_detect) * 1000
         
         # For web services, always create a new container
         # For regular code, use package hash to potentially reuse containers
@@ -745,10 +759,15 @@ export PYTHONPATH=/tmp:$PYTHONPATH
             }
         else:
             # Regular code execution - use package hash to potentially reuse containers
-            if package_hash not in self.containers:
+            cache_hit = package_hash in self.containers
+            timings['container_cache_hit'] = 1.0 if cache_hit else 0.0
+            if not cache_hit:
+                t_build = perf_counter()
                 image_tag = self._build_image(packages)
-                
+                timings['build_image_ms'] = (perf_counter() - t_build) * 1000
+
                 # Regular container for non-web services (no environment variables at creation)
+                t_run = perf_counter()
                 success, output, error = self._run_docker_command([
                     "docker", "run",
                     "-d",
@@ -763,27 +782,36 @@ export PYTHONPATH=/tmp:$PYTHONPATH
                     image_tag,
                     "tail", "-f", "/dev/null"
                 ])
+                timings['docker_run_ms'] = (perf_counter() - t_run) * 1000
                 if not success:
                     return {
                         "success": False,
                         "output": None,
-                        "error": f"Failed to create container: {error}"
+                        "error": f"Failed to create container: {error}",
+                        "timings_ms": {**timings, 'total_ms': (perf_counter() - t_start) * 1000},
                     }
                 container_id = output.strip()
                 self.containers[package_hash] = container_id
-            
+
             container_id = self.containers[package_hash]
-            
+
             # Regular code execution with environment variables injected at execution time
+            t_encode = perf_counter()
             encoded_code = base64.b64encode(code.encode()).decode()
-            success, output, error, timed_out = self._execute_with_streaming_timeout_and_env(container_id, encoded_code, timeout, env_vars)
-            
+            timings['base64_encode_ms'] = (perf_counter() - t_encode) * 1000
+
+            t_full_exec = perf_counter()
+            success, output, error, timed_out = self._execute_with_streaming_timeout_and_env(container_id, encoded_code, timeout, env_vars, timings=timings)
+            timings['full_exec_ms'] = (perf_counter() - t_full_exec) * 1000
+            timings['total_ms'] = (perf_counter() - t_start) * 1000
+
             return {
                 "success": success,
                 "output": output,
                 "error": error,
                 "container_id": container_id,
-                "timed_out": timed_out
+                "timed_out": timed_out,
+                "timings_ms": timings,
             }
     
     def cleanup(self):

--- a/code_executor.py
+++ b/code_executor.py
@@ -88,7 +88,6 @@ class CodeExecutor:
         self.container_network_mode = os.environ.get('CONTAINER_NETWORK_MODE', 'none')
         print(f"🔒 Container network mode: {self.container_network_mode}")
         self._base_image_ready = False
-        self._runtime_images_ready: Dict[str, bool] = {}
         
     def _run_docker_command(self, command: List[str], timeout: int = 30) -> Tuple[bool, str, Optional[str]]:
         """Run a Docker command and return (success, output, error)."""
@@ -313,20 +312,25 @@ USER codeuser
     # ------------------------------------------------------------------
 
     def _ensure_runtime_base_image(self, runtime: Runtime) -> None:
-        """Build the runtime's base image if it isn't already present."""
-        if self._runtime_images_ready.get(runtime.name):
-            return
+        """Build the runtime's base image if it isn't already present.
+
+        We always hit `docker image inspect` here — caching "ready=True"
+        in-process lets an image get deleted externally (by `docker rmi`,
+        GC, or a cleanup sweep) and leaves us with a stale Yes that
+        fails on the next `docker run`. The inspect is ~5ms, cheap
+        enough to do on the cold-start path.
+        """
         tag = runtime.base_image_tag
         success, _, _ = self._run_docker_command(["docker", "image", "inspect", tag])
+        if success:
+            return
+        print(f"Building {tag} from {runtime.dockerfile_path}...")
+        success, _, error = self._run_docker_command(
+            ["docker", "build", "-t", tag, "-f", runtime.dockerfile_path, "."],
+            timeout=600,
+        )
         if not success:
-            print(f"Building {tag} from {runtime.dockerfile_path}...")
-            success, _, error = self._run_docker_command(
-                ["docker", "build", "-t", tag, "-f", runtime.dockerfile_path, "."],
-                timeout=600,
-            )
-            if not success:
-                raise Exception(f"Failed to build {tag}: {error}")
-        self._runtime_images_ready[runtime.name] = True
+            raise Exception(f"Failed to build {tag}: {error}")
 
     def _build_runtime_image(self, runtime: Runtime, packages: List[str]) -> str:
         """Return an image tag for `runtime + packages`, building if needed."""

--- a/code_executor.py
+++ b/code_executor.py
@@ -22,6 +22,19 @@ logger = logging.getLogger(__name__)
 # Label used to identify containers managed by this app
 APP_LABEL = "managed-by=supakiln"
 
+# Default tmpfs size for the worker container's /tmp. Caps how much
+# scratch space user code can consume inside a single container.
+DEFAULT_TMPFS_SIZE = os.environ.get("SUPAKILN_CONTAINER_TMPFS_SIZE", "128m")
+
+
+class WorkerUnreachableError(Exception):
+    """Raised when the worker container's HTTP endpoint is unreachable.
+
+    Distinct from errors in user code (non-zero exit / stderr / timeouts):
+    those are returned as normal results. This is for "the worker process
+    itself isn't there anymore" — we should evict the cache and recreate.
+    """
+
 
 def _worker_host_from_env() -> str:
     """Resolve the hostname the backend uses to reach user-container published ports.
@@ -59,6 +72,12 @@ class CodeExecutor:
         # TCP connection to the worker when possible.
         self._http = requests.Session()
         self._worker_host = _worker_host_from_env()
+        # Concurrency: one lock per cache_key guards cold-start so parallel
+        # first-time requests for the same (language, packages) don't both
+        # build+run, leaving one orphan. The guard-lock protects the dict
+        # of per-key locks; per-key locks protect slow work.
+        self._cache_lock_guard = threading.Lock()
+        self._cache_locks: Dict[str, threading.Lock] = {}
 
         # Network mode configuration (defaults to 'none' for security)
         # Can be set to 'bridge' to allow network access when needed
@@ -372,61 +391,126 @@ USER codeuser
             time.sleep(0.05)
         raise Exception(f"worker at {host}:{port} not healthy after {timeout_s}s ({last_err})")
 
+    def _get_cache_lock(self, cache_key: str) -> threading.Lock:
+        """Return the lock for this cache_key, creating it lazily."""
+        with self._cache_lock_guard:
+            lock = self._cache_locks.get(cache_key)
+            if lock is None:
+                lock = threading.Lock()
+                self._cache_locks[cache_key] = lock
+            return lock
+
+    def _evict_worker(self, cache_key: str, container_id: Optional[str]) -> None:
+        """Forget a worker and force-remove its container (best effort).
+
+        Called when we detect the worker is unreachable or we explicitly
+        want to tear it down. Must be idempotent: the container may
+        already be gone.
+        """
+        self.worker_containers.pop(cache_key, None)
+        # Only pop endpoints if this container_id still owns it; a racing
+        # recreation could have updated it already.
+        if container_id is not None:
+            cur = self.worker_endpoints.get(container_id)
+            if cur is not None:
+                self.worker_endpoints.pop(container_id, None)
+            if self.containers.get(cache_key) == container_id:
+                self.containers.pop(cache_key, None)
+            try:
+                subprocess.run(
+                    ["docker", "rm", "-f", container_id],
+                    capture_output=True, env=os.environ.copy(),
+                    timeout=15,
+                )
+            except Exception as e:
+                logger.debug("best-effort rm failed for %s: %s", container_id, e)
+
     def _get_or_create_worker_container(
         self,
         runtime: Runtime,
         packages: List[str],
         timings: Dict[str, float],
     ) -> Tuple[str, str, int]:
-        """Return (container_id, worker_host, worker_port), creating if needed."""
+        """Return (container_id, worker_host, worker_port), creating if needed.
+
+        Cold-start is serialized per cache_key so parallel first-time
+        requests don't each build+run, leaving one orphan.
+        """
         package_hash = self._get_package_hash(packages)
         cache_key = f"{runtime.name}:{package_hash}"
 
+        # Fast path: cache hit without acquiring the per-key lock.
         if cache_key in self.worker_containers:
             container_id = self.worker_containers[cache_key]
             host, port = self.worker_endpoints[container_id]
             timings['container_cache_hit'] = 1.0
             return container_id, host, port
 
-        timings['container_cache_hit'] = 0.0
-        t_build = perf_counter()
-        image_tag = self._build_runtime_image(runtime, packages)
-        timings['build_image_ms'] = (perf_counter() - t_build) * 1000
+        lock = self._get_cache_lock(cache_key)
+        with lock:
+            # Double-check: another thread may have populated the cache
+            # while we were waiting for the lock.
+            if cache_key in self.worker_containers:
+                container_id = self.worker_containers[cache_key]
+                host, port = self.worker_endpoints[container_id]
+                timings['container_cache_hit'] = 1.0
+                return container_id, host, port
 
-        t_run = perf_counter()
-        success, output, error = self._run_docker_command([
-            "docker", "run",
-            "-d",
-            "--label", APP_LABEL,
-            "--memory", "512m",
-            "--cpus", "0.5",
-            "--network", "bridge",  # worker needs network; dind bridge only
-            "--user", "1000:1000",
-            "--cap-drop", "ALL",
-            "--pids-limit", "100",
-            "-p", str(runtime.worker_port),  # publish to random host port on dind
-            image_tag,
-        ])
-        timings['docker_run_ms'] = (perf_counter() - t_run) * 1000
-        if not success:
-            raise Exception(f"Failed to create worker container: {error}")
-        container_id = output.strip()
+            timings['container_cache_hit'] = 0.0
+            t_build = perf_counter()
+            image_tag = self._build_runtime_image(runtime, packages)
+            timings['build_image_ms'] = (perf_counter() - t_build) * 1000
 
-        t_port = perf_counter()
-        host_port = self._read_worker_port(container_id, runtime.worker_port)
-        timings['read_port_ms'] = (perf_counter() - t_port) * 1000
+            t_run = perf_counter()
+            success, output, error = self._run_docker_command([
+                "docker", "run",
+                "-d",
+                "--label", APP_LABEL,
+                "--memory", "512m",
+                "--cpus", "0.5",
+                "--network", "bridge",  # worker needs network; dind bridge only
+                "--user", "1000:1000",
+                "--cap-drop", "ALL",
+                "--pids-limit", "100",
+                # Tmpfs for /tmp so user code can't indefinitely grow the
+                # container's writable layer. 128m is enough for realistic
+                # scratch work; override with SUPAKILN_CONTAINER_TMPFS_SIZE.
+                "--tmpfs", f"/tmp:size={DEFAULT_TMPFS_SIZE},mode=1777",
+                "-p", str(runtime.worker_port),  # publish to random host port on dind
+                image_tag,
+            ])
+            timings['docker_run_ms'] = (perf_counter() - t_run) * 1000
+            if not success:
+                raise Exception(f"Failed to create worker container: {error}")
+            container_id = output.strip()
 
-        host = self._worker_host
-        t_health = perf_counter()
-        self._wait_for_worker_health(host, host_port)
-        timings['worker_health_ms'] = (perf_counter() - t_health) * 1000
+            try:
+                t_port = perf_counter()
+                host_port = self._read_worker_port(container_id, runtime.worker_port)
+                timings['read_port_ms'] = (perf_counter() - t_port) * 1000
 
-        self.worker_containers[cache_key] = container_id
-        self.worker_endpoints[container_id] = (host, host_port)
-        # Also register in the legacy `containers` dict so existing code
-        # (debug endpoints, container_id lookups) still works.
-        self.containers[cache_key] = container_id
-        return container_id, host, host_port
+                host = self._worker_host
+                t_health = perf_counter()
+                self._wait_for_worker_health(host, host_port)
+                timings['worker_health_ms'] = (perf_counter() - t_health) * 1000
+            except Exception:
+                # If we couldn't bring the worker up, don't leave the
+                # container running as an orphan.
+                try:
+                    subprocess.run(
+                        ["docker", "rm", "-f", container_id],
+                        capture_output=True, env=os.environ.copy(), timeout=15,
+                    )
+                except Exception:
+                    pass
+                raise
+
+            self.worker_containers[cache_key] = container_id
+            self.worker_endpoints[container_id] = (host, host_port)
+            # Also register in the legacy `containers` dict so existing code
+            # (debug endpoints, container_id lookups) still works.
+            self.containers[cache_key] = container_id
+            return container_id, host, host_port
 
     def _exec_via_worker(
         self,
@@ -436,7 +520,13 @@ USER codeuser
         env_vars: Dict[str, str],
         timeout_ms: int,
     ) -> Tuple[bool, Optional[str], Optional[str], bool]:
-        """POST code to the worker; return (success, stdout, stderr, timed_out)."""
+        """POST code to the worker; return (success, stdout, stderr, timed_out).
+
+        Raises WorkerUnreachableError if the worker HTTP endpoint can't be
+        reached at all — the caller should evict cache and retry. Does NOT
+        raise for user-code failures (non-zero exit, stderr, timed_out);
+        those come back as normal return values.
+        """
         url = f"http://{host}:{port}/exec"
         # Worker enforces timeout on its side; we give the HTTP client a
         # small slack buffer so the server can surface a timed_out=True
@@ -448,11 +538,24 @@ USER codeuser
                 json={"code": code, "env": env_vars or {}, "timeout_ms": timeout_ms},
                 timeout=http_timeout,
             )
+        except requests.ConnectionError as e:
+            # Worker is gone (container died, daemon restarted, TCP reset).
+            raise WorkerUnreachableError(f"worker connection failed: {e}") from e
         except requests.Timeout:
+            # User's code or the worker hung. This can be either "user
+            # code took too long" or "worker stuck"; treat the latter as
+            # a user-visible timeout rather than an unreachable marker,
+            # because the container is usually still alive.
             return False, None, "worker HTTP request timed out", True
         except requests.RequestException as e:
             return False, None, f"worker request failed: {e}", False
 
+        if r.status_code >= 500:
+            # Server-side error from the worker; the process may be in a
+            # bad state. Treat as unreachable so the caller recreates.
+            raise WorkerUnreachableError(
+                f"worker returned status {r.status_code}: {r.text[:200]}"
+            )
         if r.status_code != 200:
             return False, None, f"worker returned status {r.status_code}: {r.text}", False
         try:
@@ -1009,26 +1112,58 @@ export PYTHONPATH=/tmp:$PYTHONPATH
                     "timings_ms": timings,
                 }
 
-            try:
-                container_id, host, port = self._get_or_create_worker_container(
-                    runtime, packages, timings,
-                )
-            except Exception as e:
+            package_hash = self._get_package_hash(packages)
+            cache_key = f"{runtime.name}:{package_hash}"
+
+            # We allow one automatic retry if the cached worker turns out
+            # to be dead — that's the self-heal path. A second consecutive
+            # unreachable worker is reported to the caller.
+            last_unreachable: Optional[WorkerUnreachableError] = None
+            container_id: Optional[str] = None
+            for attempt in range(2):
+                try:
+                    container_id, host, port = self._get_or_create_worker_container(
+                        runtime, packages, timings,
+                    )
+                except Exception as e:
+                    timings['total_ms'] = (perf_counter() - t_start) * 1000
+                    return {
+                        "success": False,
+                        "output": None,
+                        "error": f"Failed to prepare worker container: {e}",
+                        "timings_ms": timings,
+                    }
+
+                t_exec = perf_counter()
+                try:
+                    success, stdout, stderr, timed_out = self._exec_via_worker(
+                        host, port, code, env_vars, timeout_ms=int(timeout * 1000),
+                    )
+                    timings['worker_exec_ms'] = (perf_counter() - t_exec) * 1000
+                    if attempt == 1:
+                        timings['self_heal_recovered'] = 1.0
+                    break
+                except WorkerUnreachableError as e:
+                    last_unreachable = e
+                    timings['worker_exec_ms'] = (perf_counter() - t_exec) * 1000
+                    timings[f'self_heal_attempt_{attempt}'] = 1.0
+                    # Evict the dead worker. Next iteration rebuilds.
+                    self._evict_worker(cache_key, container_id)
+                    container_id = None
+            else:
+                # Both attempts failed — worker couldn't be reached even
+                # after recreating. Surface a clear error.
                 timings['total_ms'] = (perf_counter() - t_start) * 1000
                 return {
                     "success": False,
                     "output": None,
-                    "error": f"Failed to prepare worker container: {e}",
+                    "error": f"Worker unreachable after retry: {last_unreachable}",
+                    "container_id": None,
+                    "timed_out": False,
                     "timings_ms": timings,
                 }
 
-            t_exec = perf_counter()
-            success, stdout, stderr, timed_out = self._exec_via_worker(
-                host, port, code, env_vars, timeout_ms=int(timeout * 1000),
-            )
-            timings['worker_exec_ms'] = (perf_counter() - t_exec) * 1000
             timings['total_ms'] = (perf_counter() - t_start) * 1000
-
             output = stdout if stdout else None
             # Preserve existing contract: stderr is returned as `error` iff
             # the process actually failed (non-zero exit or timeout); a

--- a/code_executor.py
+++ b/code_executor.py
@@ -8,27 +8,64 @@ import base64
 import docker
 import random
 import logging
+import requests
 from time import perf_counter
 from typing import Dict, List, Optional, Tuple
 from concurrent.futures import ThreadPoolExecutor, TimeoutError
+from urllib.parse import urlparse
 from services.docker_client import docker_client
+from languages import get as get_runtime
+from languages.base import Runtime, build_package_install_snippet
 
 logger = logging.getLogger(__name__)
 
 # Label used to identify containers managed by this app
 APP_LABEL = "managed-by=supakiln"
 
+
+def _worker_host_from_env() -> str:
+    """Resolve the hostname the backend uses to reach user-container published ports.
+
+    In the docker-compose/dind setup, published ports bind on the dind
+    daemon's host (the `docker-daemon` service). If DOCKER_HOST is a TCP
+    URL, its hostname is that. Otherwise (host docker socket), user
+    containers publish to localhost.
+    """
+    override = os.environ.get("SUPAKILN_WORKER_HOST")
+    if override:
+        return override
+    docker_host = os.environ.get("DOCKER_HOST", "")
+    if docker_host.startswith("tcp://"):
+        parsed = urlparse(docker_host)
+        return parsed.hostname or "localhost"
+    return "localhost"
+
+
 class CodeExecutor:
     def __init__(self, image_name: str = "python-executor"):
+        # Legacy image name retained for the web-service execution path,
+        # which still uses the pre-existing `python-executor:*` images.
         self.image_name = image_name
-        self.containers: Dict[str, str] = {}  # package_hash -> container_id
+        # Legacy cache: package_hash -> container_id (used by web services
+        # and debug endpoints). Kept for backwards compatibility.
+        self.containers: Dict[str, str] = {}
         self.web_service_containers: Dict[str, Dict] = {}  # container_id -> service_info
+
+        # Worker-path cache: "lang:package_hash" -> container_id
+        self.worker_containers: Dict[str, str] = {}
+        # Worker endpoints: container_id -> (host, port) to reach its HTTP API
+        self.worker_endpoints: Dict[str, Tuple[str, int]] = {}
+        # HTTP session with connection pooling so each /exec POST reuses a
+        # TCP connection to the worker when possible.
+        self._http = requests.Session()
+        self._worker_host = _worker_host_from_env()
 
         # Network mode configuration (defaults to 'none' for security)
         # Can be set to 'bridge' to allow network access when needed
         self.container_network_mode = os.environ.get('CONTAINER_NETWORK_MODE', 'none')
         print(f"🔒 Container network mode: {self.container_network_mode}")
         self._base_image_ready = False
+        self._runtime_images_ready: Dict[str, bool] = {}
         
     def _run_docker_command(self, command: List[str], timeout: int = 30) -> Tuple[bool, str, Optional[str]]:
         """Run a Docker command and return (success, output, error)."""
@@ -243,6 +280,193 @@ USER codeuser
         
         return f"Failed to build image with packages: {', '.join(packages)}\n\nFull error: {docker_error}"
 
+    # ------------------------------------------------------------------
+    # Runtime + worker path (ad-hoc execution, multi-language)
+    #
+    # Each supported language has its own base image (e.g.
+    # `supakiln-python:base`) with a long-running HTTP worker baked in as
+    # CMD. Backend talks to the worker directly over the dind bridge
+    # (via published ports), bypassing `docker exec` on the hot path.
+    # ------------------------------------------------------------------
+
+    def _ensure_runtime_base_image(self, runtime: Runtime) -> None:
+        """Build the runtime's base image if it isn't already present."""
+        if self._runtime_images_ready.get(runtime.name):
+            return
+        tag = runtime.base_image_tag
+        success, _, _ = self._run_docker_command(["docker", "image", "inspect", tag])
+        if not success:
+            print(f"Building {tag} from {runtime.dockerfile_path}...")
+            success, _, error = self._run_docker_command(
+                ["docker", "build", "-t", tag, "-f", runtime.dockerfile_path, "."],
+                timeout=600,
+            )
+            if not success:
+                raise Exception(f"Failed to build {tag}: {error}")
+        self._runtime_images_ready[runtime.name] = True
+
+    def _build_runtime_image(self, runtime: Runtime, packages: List[str]) -> str:
+        """Return an image tag for `runtime + packages`, building if needed."""
+        self._ensure_runtime_base_image(runtime)
+        if not packages:
+            return runtime.base_image_tag
+
+        package_hash = self._get_package_hash(packages)
+        base_name = runtime.base_image_tag.split(":", 1)[0]
+        image_tag = f"{base_name}:{package_hash}"
+
+        success, _, _ = self._run_docker_command(["docker", "image", "inspect", image_tag])
+        if success:
+            return image_tag
+
+        install_snippet = build_package_install_snippet(runtime, packages)
+        if not install_snippet:
+            # Runtime doesn't support package installation; callers should
+            # not be passing packages, but fall back to base image rather
+            # than erroring.
+            return runtime.base_image_tag
+
+        dockerfile_content = (
+            f"FROM {runtime.base_image_tag}\n"
+            f"{install_snippet}"
+        )
+        tmp_path = f"Dockerfile.{runtime.name}.{package_hash}.tmp"
+        with open(tmp_path, "w") as f:
+            f.write(dockerfile_content)
+        try:
+            success, _, error = self._run_docker_command(
+                ["docker", "build", "-t", image_tag, "-f", tmp_path, "."],
+                timeout=600,
+            )
+            if not success:
+                raise Exception(self._parse_docker_build_error(error, packages))
+        finally:
+            if os.path.exists(tmp_path):
+                os.remove(tmp_path)
+        return image_tag
+
+    def _read_worker_port(self, container_id: str, worker_port: int) -> int:
+        """Read the published host-port for the worker container."""
+        container = docker_client.containers.get(container_id)
+        container.reload()
+        port_info = (container.attrs.get("NetworkSettings", {})
+                     .get("Ports", {})
+                     .get(f"{worker_port}/tcp"))
+        if not port_info:
+            raise Exception(f"worker port {worker_port} not published on {container_id[:12]}")
+        return int(port_info[0]["HostPort"])
+
+    def _wait_for_worker_health(self, host: str, port: int, timeout_s: float = 15.0) -> None:
+        """Poll GET /health until 200 or timeout."""
+        deadline = perf_counter() + timeout_s
+        url = f"http://{host}:{port}/health"
+        last_err: Optional[str] = None
+        while perf_counter() < deadline:
+            try:
+                r = self._http.get(url, timeout=1.0)
+                if r.status_code == 200:
+                    return
+                last_err = f"status={r.status_code}"
+            except requests.RequestException as e:
+                last_err = str(e)
+            time.sleep(0.05)
+        raise Exception(f"worker at {host}:{port} not healthy after {timeout_s}s ({last_err})")
+
+    def _get_or_create_worker_container(
+        self,
+        runtime: Runtime,
+        packages: List[str],
+        timings: Dict[str, float],
+    ) -> Tuple[str, str, int]:
+        """Return (container_id, worker_host, worker_port), creating if needed."""
+        package_hash = self._get_package_hash(packages)
+        cache_key = f"{runtime.name}:{package_hash}"
+
+        if cache_key in self.worker_containers:
+            container_id = self.worker_containers[cache_key]
+            host, port = self.worker_endpoints[container_id]
+            timings['container_cache_hit'] = 1.0
+            return container_id, host, port
+
+        timings['container_cache_hit'] = 0.0
+        t_build = perf_counter()
+        image_tag = self._build_runtime_image(runtime, packages)
+        timings['build_image_ms'] = (perf_counter() - t_build) * 1000
+
+        t_run = perf_counter()
+        success, output, error = self._run_docker_command([
+            "docker", "run",
+            "-d",
+            "--label", APP_LABEL,
+            "--memory", "512m",
+            "--cpus", "0.5",
+            "--network", "bridge",  # worker needs network; dind bridge only
+            "--user", "1000:1000",
+            "--cap-drop", "ALL",
+            "--pids-limit", "100",
+            "-p", str(runtime.worker_port),  # publish to random host port on dind
+            image_tag,
+        ])
+        timings['docker_run_ms'] = (perf_counter() - t_run) * 1000
+        if not success:
+            raise Exception(f"Failed to create worker container: {error}")
+        container_id = output.strip()
+
+        t_port = perf_counter()
+        host_port = self._read_worker_port(container_id, runtime.worker_port)
+        timings['read_port_ms'] = (perf_counter() - t_port) * 1000
+
+        host = self._worker_host
+        t_health = perf_counter()
+        self._wait_for_worker_health(host, host_port)
+        timings['worker_health_ms'] = (perf_counter() - t_health) * 1000
+
+        self.worker_containers[cache_key] = container_id
+        self.worker_endpoints[container_id] = (host, host_port)
+        # Also register in the legacy `containers` dict so existing code
+        # (debug endpoints, container_id lookups) still works.
+        self.containers[cache_key] = container_id
+        return container_id, host, host_port
+
+    def _exec_via_worker(
+        self,
+        host: str,
+        port: int,
+        code: str,
+        env_vars: Dict[str, str],
+        timeout_ms: int,
+    ) -> Tuple[bool, Optional[str], Optional[str], bool]:
+        """POST code to the worker; return (success, stdout, stderr, timed_out)."""
+        url = f"http://{host}:{port}/exec"
+        # Worker enforces timeout on its side; we give the HTTP client a
+        # small slack buffer so the server can surface a timed_out=True
+        # response rather than us hanging up.
+        http_timeout = max(1.0, timeout_ms / 1000.0 + 5.0)
+        try:
+            r = self._http.post(
+                url,
+                json={"code": code, "env": env_vars or {}, "timeout_ms": timeout_ms},
+                timeout=http_timeout,
+            )
+        except requests.Timeout:
+            return False, None, "worker HTTP request timed out", True
+        except requests.RequestException as e:
+            return False, None, f"worker request failed: {e}", False
+
+        if r.status_code != 200:
+            return False, None, f"worker returned status {r.status_code}: {r.text}", False
+        try:
+            body = r.json()
+        except ValueError:
+            return False, None, f"worker returned non-JSON: {r.text[:200]}", False
+        success = body.get("exit_code") == 0 and not body.get("timed_out", False)
+        return (
+            success,
+            body.get("stdout"),
+            body.get("stderr"),
+            bool(body.get("timed_out", False)),
+        )
+
     def _execute_with_timeout(self, container_id: str, command: str, timeout: int) -> Tuple[bool, str, Optional[str]]:
         """Execute a command in a container with timeout."""
         try:
@@ -427,15 +651,24 @@ USER codeuser
         
         return success and not timed_out, combined_output, combined_error, timed_out
     
-    def execute_code(self, code: str, packages: List[str], timeout: int = 30, env_vars: Dict[str, str] = None) -> Dict:
+    def execute_code(
+        self,
+        code: str,
+        packages: List[str],
+        timeout: int = 30,
+        env_vars: Dict[str, str] = None,
+        language: str = "python",
+    ) -> Dict:
         """
-        Execute Python code in a container with the specified packages.
+        Execute code in a container with the specified packages.
 
         Args:
-            code: Python code to execute
-            packages: List of required Python packages
+            code: Source code to execute
+            packages: List of required packages (interpretation depends on language)
             timeout: Maximum execution time in seconds
             env_vars: Dictionary of environment variables to pass to the container
+            language: Runtime to use (default "python"). Must be registered
+                      in the `languages` module.
 
         Returns:
             Dict containing execution results
@@ -450,10 +683,14 @@ USER codeuser
         package_hash = self._get_package_hash(packages)
         timings['package_hash_ms'] = (perf_counter() - t_hash) * 1000
 
-        # Detect if this is a web service
-        t_detect = perf_counter()
-        web_service = self._detect_web_service(code, packages)
-        timings['detect_web_service_ms'] = (perf_counter() - t_detect) * 1000
+        # Web-service detection only applies to Python (Streamlit/FastAPI/
+        # Flask/Dash/Gradio). Non-Python languages always take the ad-hoc
+        # worker path.
+        web_service = None
+        if language == "python":
+            t_detect = perf_counter()
+            web_service = self._detect_web_service(code, packages)
+            timings['detect_web_service_ms'] = (perf_counter() - t_detect) * 1000
         
         # For web services, always create a new container
         # For regular code, use package hash to potentially reuse containers
@@ -758,53 +995,45 @@ export PYTHONPATH=/tmp:$PYTHONPATH
                 }
             }
         else:
-            # Regular code execution - use package hash to potentially reuse containers
-            cache_hit = package_hash in self.containers
-            timings['container_cache_hit'] = 1.0 if cache_hit else 0.0
-            if not cache_hit:
-                t_build = perf_counter()
-                image_tag = self._build_image(packages)
-                timings['build_image_ms'] = (perf_counter() - t_build) * 1000
+            # Ad-hoc code execution via the per-language worker. Containers
+            # are cached per (language, package_hash) so subsequent runs
+            # against the same environment reuse the live worker.
+            try:
+                runtime = get_runtime(language)
+            except KeyError as e:
+                timings['total_ms'] = (perf_counter() - t_start) * 1000
+                return {
+                    "success": False,
+                    "output": None,
+                    "error": str(e),
+                    "timings_ms": timings,
+                }
 
-                # Regular container for non-web services (no environment variables at creation)
-                t_run = perf_counter()
-                success, output, error = self._run_docker_command([
-                    "docker", "run",
-                    "-d",
-                    "--label", APP_LABEL,
-                    "--memory", "512m",
-                    "--cpus", "0.5",
-                    "--network", self.container_network_mode,  # Configurable network mode
-                    "--user", "1000:1000",
-                    "--cap-drop", "ALL",  # Remove all capabilities
-                    "--pids-limit", "100"  # Limit number of processes (keep reasonable limit)
-                ] + [
-                    image_tag,
-                    "tail", "-f", "/dev/null"
-                ])
-                timings['docker_run_ms'] = (perf_counter() - t_run) * 1000
-                if not success:
-                    return {
-                        "success": False,
-                        "output": None,
-                        "error": f"Failed to create container: {error}",
-                        "timings_ms": {**timings, 'total_ms': (perf_counter() - t_start) * 1000},
-                    }
-                container_id = output.strip()
-                self.containers[package_hash] = container_id
+            try:
+                container_id, host, port = self._get_or_create_worker_container(
+                    runtime, packages, timings,
+                )
+            except Exception as e:
+                timings['total_ms'] = (perf_counter() - t_start) * 1000
+                return {
+                    "success": False,
+                    "output": None,
+                    "error": f"Failed to prepare worker container: {e}",
+                    "timings_ms": timings,
+                }
 
-            container_id = self.containers[package_hash]
-
-            # Regular code execution with environment variables injected at execution time
-            t_encode = perf_counter()
-            encoded_code = base64.b64encode(code.encode()).decode()
-            timings['base64_encode_ms'] = (perf_counter() - t_encode) * 1000
-
-            t_full_exec = perf_counter()
-            success, output, error, timed_out = self._execute_with_streaming_timeout_and_env(container_id, encoded_code, timeout, env_vars, timings=timings)
-            timings['full_exec_ms'] = (perf_counter() - t_full_exec) * 1000
+            t_exec = perf_counter()
+            success, stdout, stderr, timed_out = self._exec_via_worker(
+                host, port, code, env_vars, timeout_ms=int(timeout * 1000),
+            )
+            timings['worker_exec_ms'] = (perf_counter() - t_exec) * 1000
             timings['total_ms'] = (perf_counter() - t_start) * 1000
 
+            output = stdout if stdout else None
+            # Preserve existing contract: stderr is returned as `error` iff
+            # the process actually failed (non-zero exit or timeout); a
+            # successful run with stderr chatter still reports success.
+            error = stderr if (not success or timed_out) and stderr else None
             return {
                 "success": success,
                 "output": output,
@@ -817,14 +1046,20 @@ export PYTHONPATH=/tmp:$PYTHONPATH
     def cleanup(self):
         """Clean up all tracked containers."""
         env = os.environ.copy()
-        all_ids = list(self.containers.values()) + list(self.web_service_containers.keys())
-        for container_id in all_ids:
+        all_ids = (
+            list(self.containers.values())
+            + list(self.web_service_containers.keys())
+            + list(self.worker_containers.values())
+        )
+        for container_id in set(all_ids):
             try:
                 subprocess.run(["docker", "rm", "-f", container_id], capture_output=True, env=env)
             except Exception:
                 pass
         self.containers.clear()
         self.web_service_containers.clear()
+        self.worker_containers.clear()
+        self.worker_endpoints.clear()
 
     def shutdown(self):
         """Graceful shutdown: stop and remove all tracked containers."""

--- a/code_executor.py
+++ b/code_executor.py
@@ -3,6 +3,7 @@ import os
 import json
 import time
 import hashlib
+import secrets
 import threading
 import base64
 import docker
@@ -34,6 +35,18 @@ class WorkerUnreachableError(Exception):
     those are returned as normal results. This is for "the worker process
     itself isn't there anymore" — we should evict the cache and recreate.
     """
+
+
+class WorkerCapError(Exception):
+    """Raised when worker count caps prevent creating a new container.
+
+    Carries an `http_status` (429 for per-user cap, 503 for global) so the
+    API layer can map to the right response code.
+    """
+
+    def __init__(self, message: str, http_status: int):
+        super().__init__(message)
+        self.http_status = http_status
 
 
 def _worker_host_from_env() -> str:
@@ -82,6 +95,14 @@ class CodeExecutor:
         # of per-key locks; per-key locks protect slow work.
         self._cache_lock_guard = threading.Lock()
         self._cache_locks: Dict[str, threading.Lock] = {}
+
+        # In-flight /exec calls per container. The evictor (cap-enforcer
+        # and pressure reaper) will never pick a container with
+        # busy_count > 0. Incremented before returning from
+        # `_get_or_create_worker_container`; decremented in the caller's
+        # `finally`. Protected by _busy_lock.
+        self._busy_counts: Dict[str, int] = {}
+        self._busy_lock = threading.Lock()
 
         # Network mode configuration (defaults to 'none' for security)
         # Can be set to 'bridge' to allow network access when needed
@@ -434,25 +455,270 @@ USER codeuser
             except Exception as e:
                 logger.debug("best-effort rm failed for %s: %s", container_id, e)
 
+    # ------------------------------------------------------------------
+    # Busy-count tracking.
+    #
+    # We must NOT evict a worker that is mid-call — that would racily tear
+    # the container out from under an in-flight request. `_mark_busy` is
+    # called right before returning from `_get_or_create_worker_container`
+    # so there is no gap between "I'm using this worker" and "it's marked
+    # busy". The caller (`execute_code`) drops it in a `finally`.
+    # ------------------------------------------------------------------
+
+    def _mark_busy(self, container_id: str) -> None:
+        with self._busy_lock:
+            self._busy_counts[container_id] = (
+                self._busy_counts.get(container_id, 0) + 1
+            )
+
+    def _mark_idle(self, container_id: str) -> None:
+        with self._busy_lock:
+            cur = self._busy_counts.get(container_id, 0)
+            if cur <= 1:
+                self._busy_counts.pop(container_id, None)
+            else:
+                self._busy_counts[container_id] = cur - 1
+
+    def _is_busy(self, container_id: str) -> bool:
+        with self._busy_lock:
+            return self._busy_counts.get(container_id, 0) > 0
+
+    # ------------------------------------------------------------------
+    # Cap enforcement + pressure eviction.
+    # ------------------------------------------------------------------
+
+    @staticmethod
+    def _get_caps() -> Tuple[int, int]:
+        """Read (max_global, max_per_user) from env on every call.
+
+        Defaults are intentionally modest — a single-host dind has a
+        hard memory ceiling, and each worker holds ~50MB idle + up to
+        the 512MB --memory limit. 50 workers × ~100MB working-set is
+        already ~5GB. 5/user prevents one tenant from monopolising.
+        """
+        try:
+            mx = int(os.environ.get("SUPAKILN_MAX_WORKERS", "50"))
+        except ValueError:
+            mx = 50
+        try:
+            mxu = int(os.environ.get("SUPAKILN_MAX_WORKERS_PER_USER", "5"))
+        except ValueError:
+            mxu = 5
+        return mx, mxu
+
+    def _user_workers(self, user_id: int) -> List[Tuple[str, Dict]]:
+        return [
+            (cid, meta)
+            for cid, meta in self.worker_meta.items()
+            if meta.get("user_id") == user_id
+        ]
+
+    def _evict_for_caps(self, user_id: int) -> None:
+        """Make room before creating a new worker for `user_id`.
+
+        Per-user cap fires first (most common quota trigger); global cap
+        catches the aggregate. In both cases we pick the LRU idle worker
+        to evict. If all candidates are busy, raise WorkerCapError so
+        the API can return 429/503 and the client can retry.
+
+        Must be called with the caller's cache_lock already held — this
+        keeps eviction and new-container-creation atomic for the same
+        cache_key.
+        """
+        max_global, max_per_user = self._get_caps()
+
+        # Per-user cap. Evict the caller's own LRU idle worker first; if
+        # none of theirs are idle, refuse.
+        user_workers = self._user_workers(user_id)
+        if len(user_workers) >= max_per_user:
+            idle = [(cid, m) for cid, m in user_workers if not self._is_busy(cid)]
+            if not idle:
+                raise WorkerCapError(
+                    f"per-user worker cap reached "
+                    f"({max_per_user}) and all are busy",
+                    http_status=429,
+                )
+            idle.sort(key=lambda pair: pair[1]["last_used"])
+            victim_cid, victim_meta = idle[0]
+            logger.info(
+                "Cap-evicting user %s's LRU worker %s (cache_key=%s)",
+                user_id, victim_cid[:12], victim_meta["cache_key"],
+            )
+            self._evict_worker(victim_meta["cache_key"], victim_cid)
+
+        # Global cap. Evict the globally-LRU idle worker, which may or
+        # may not belong to this user.
+        if len(self.worker_meta) >= max_global:
+            idle = [
+                (cid, m) for cid, m in self.worker_meta.items()
+                if not self._is_busy(cid)
+            ]
+            if not idle:
+                raise WorkerCapError(
+                    f"global worker cap reached "
+                    f"({max_global}) and all are busy",
+                    http_status=503,
+                )
+            idle.sort(key=lambda pair: pair[1]["last_used"])
+            victim_cid, victim_meta = idle[0]
+            logger.info(
+                "Cap-evicting global LRU worker %s (user=%s, cache_key=%s)",
+                victim_cid[:12],
+                victim_meta.get("user_id"),
+                victim_meta["cache_key"],
+            )
+            self._evict_worker(victim_meta["cache_key"], victim_cid)
+
+    # ------------------------------------------------------------------
+    # Pressure reapers (called by the scheduler's background thread).
+    # ------------------------------------------------------------------
+
+    @staticmethod
+    def _read_host_memory_pct() -> Optional[float]:
+        """Return used-memory fraction (0..1) from /proc/meminfo.
+
+        Uses MemAvailable when present (it's the kernel's own estimate
+        of "memory that can be allocated without swapping"), which is
+        the right signal for eviction decisions. Falls back to
+        Total-Free-Cached-Buffers on older kernels.
+        """
+        try:
+            with open("/proc/meminfo", "r") as f:
+                fields = {}
+                for line in f:
+                    k, _, rest = line.partition(":")
+                    v = rest.strip().split()
+                    if v:
+                        try:
+                            fields[k] = int(v[0])
+                        except ValueError:
+                            pass
+        except OSError:
+            return None
+        total = fields.get("MemTotal")
+        if not total:
+            return None
+        avail = fields.get("MemAvailable")
+        if avail is None:
+            free = fields.get("MemFree", 0)
+            cached = fields.get("Cached", 0)
+            buffers = fields.get("Buffers", 0)
+            avail = free + cached + buffers
+        used = total - avail
+        return max(0.0, min(1.0, used / total))
+
+    @staticmethod
+    def _read_host_loadavg_1m() -> Optional[float]:
+        try:
+            with open("/proc/loadavg", "r") as f:
+                parts = f.read().split()
+            if parts:
+                return float(parts[0])
+        except (OSError, ValueError):
+            pass
+        return None
+
+    def _idle_lru(self) -> List[Tuple[str, Dict]]:
+        """Return non-busy workers sorted oldest-used-first."""
+        idle = [
+            (cid, m) for cid, m in self.worker_meta.items()
+            if not self._is_busy(cid)
+        ]
+        idle.sort(key=lambda pair: pair[1]["last_used"])
+        return idle
+
+    def reap_memory_pressure(self) -> List[str]:
+        """Evict LRU idle workers while host memory is above high water.
+
+        Two thresholds avoid thrash:
+          SUPAKILN_MEMORY_HIGH_WATER_PCT  start reaping when used > this
+          SUPAKILN_MEMORY_LOW_WATER_PCT   stop when used drops below
+        Returns the list of container_ids reaped (empty if nothing to do).
+        """
+        try:
+            high = float(os.environ.get("SUPAKILN_MEMORY_HIGH_WATER_PCT", "85")) / 100.0
+        except ValueError:
+            high = 0.85
+        try:
+            low = float(os.environ.get("SUPAKILN_MEMORY_LOW_WATER_PCT", "70")) / 100.0
+        except ValueError:
+            low = 0.70
+        if low >= high:
+            low = max(0.0, high - 0.10)
+
+        used = self._read_host_memory_pct()
+        if used is None or used < high:
+            return []
+
+        reaped: List[str] = []
+        for cid, meta in self._idle_lru():
+            self._evict_worker(meta["cache_key"], cid)
+            reaped.append(cid)
+            # Re-check after each eviction; the kernel is slow to
+            # reclaim tmpfs pages, so we don't always see a drop
+            # immediately. Cap the batch at len(idle) workers.
+            used = self._read_host_memory_pct()
+            if used is not None and used <= low:
+                break
+        return reaped
+
+    def reap_cpu_pressure(self) -> List[str]:
+        """Evict LRU idle workers while 1-min load exceeds SUPAKILN_CPU_HIGH_WATER.
+
+        Default high water is `nproc * 1.5`, i.e. "hosts is noticeably
+        overloaded but not dead". Unlike memory this is often transient;
+        the reaper runs often enough that a single spike is tolerable.
+        """
+        default_high = float(os.cpu_count() or 1) * 1.5
+        try:
+            high = float(
+                os.environ.get("SUPAKILN_CPU_HIGH_WATER", str(default_high))
+            )
+        except ValueError:
+            high = default_high
+
+        load = self._read_host_loadavg_1m()
+        if load is None or load < high:
+            return []
+
+        reaped: List[str] = []
+        # Evict at most 25% of idle workers per tick to avoid cliffs.
+        idle = self._idle_lru()
+        budget = max(1, len(idle) // 4)
+        for cid, meta in idle[:budget]:
+            self._evict_worker(meta["cache_key"], cid)
+            reaped.append(cid)
+        return reaped
+
     def _get_or_create_worker_container(
         self,
         runtime: Runtime,
         packages: List[str],
         timings: Dict[str, float],
+        user_id: int,
     ) -> Tuple[str, str, int]:
         """Return (container_id, worker_host, worker_port), creating if needed.
 
         Cold-start is serialized per cache_key so parallel first-time
         requests don't each build+run, leaving one orphan.
+
+        `user_id` is part of the cache key: every tenant gets their own
+        worker container for a given (language, packages). This is the
+        primary multi-tenant isolation boundary — one user's filesystem,
+        process, and network state never touch another's.
         """
         package_hash = self._get_package_hash(packages)
-        cache_key = f"{runtime.name}:{package_hash}"
+        cache_key = f"{runtime.name}:u{user_id}:{package_hash}"
 
         # Fast path: cache hit without acquiring the per-key lock.
         if cache_key in self.worker_containers:
             container_id = self.worker_containers[cache_key]
             host, port = self.worker_endpoints[container_id]
             timings['container_cache_hit'] = 1.0
+            # Mark busy BEFORE returning so a concurrent evictor doesn't
+            # pick this container in the window between return and the
+            # caller's subsequent _exec_via_worker call.
+            self._mark_busy(container_id)
             return container_id, host, port
 
         lock = self._get_cache_lock(cache_key)
@@ -463,12 +729,25 @@ USER codeuser
                 container_id = self.worker_containers[cache_key]
                 host, port = self.worker_endpoints[container_id]
                 timings['container_cache_hit'] = 1.0
+                self._mark_busy(container_id)
                 return container_id, host, port
 
             timings['container_cache_hit'] = 0.0
+
+            # About to create a new worker — make room first. This may
+            # raise WorkerCapError(429/503), which bubbles up cleanly.
+            self._evict_for_caps(user_id)
+
             t_build = perf_counter()
             image_tag = self._build_runtime_image(runtime, packages)
             timings['build_image_ms'] = (perf_counter() - t_build) * 1000
+
+            # Mint a one-time shared secret and pass it as an env var.
+            # The worker enforces it on /exec; sibling containers on the
+            # same dind bridge no longer have an unauthenticated escape
+            # hatch to each other. secrets.token_urlsafe returns ~43
+            # chars of entropy from 32 bytes.
+            worker_token = secrets.token_urlsafe(32)
 
             t_run = perf_counter()
             success, output, error = self._run_docker_command([
@@ -481,10 +760,22 @@ USER codeuser
                 "--user", "1000:1000",
                 "--cap-drop", "ALL",
                 "--pids-limit", "100",
+                # Block setuid escalation via /usr/bin/su, passwd, etc.
+                "--security-opt", "no-new-privileges",
+                # Rootfs read-only; writable areas are explicit tmpfs
+                # mounts. A future Dockerfile regression that chowns a
+                # system dir to codeuser no longer becomes a persistence
+                # vector.
+                "--read-only",
                 # Tmpfs for /tmp so user code can't indefinitely grow the
                 # container's writable layer. 128m is enough for realistic
                 # scratch work; override with SUPAKILN_CONTAINER_TMPFS_SIZE.
                 "--tmpfs", f"/tmp:size={DEFAULT_TMPFS_SIZE},mode=1777",
+                # Writable home, also tmpfs so it resets with the
+                # container. Keeps install-free languages (bash, go)
+                # working when they want a writable $HOME.
+                "--tmpfs", "/home/codeuser:size=16m,mode=0755,uid=1000,gid=1000",
+                "-e", f"SUPAKILN_WORKER_TOKEN={worker_token}",
                 "-p", str(runtime.worker_port),  # publish to random host port on dind
                 image_tag,
             ])
@@ -521,12 +812,17 @@ USER codeuser
                 "language": runtime.name,
                 "package_hash": package_hash,
                 "cache_key": cache_key,
+                "user_id": user_id,
                 "created_at": now,
                 "last_used": now,
+                "worker_token": worker_token,
             }
             # Also register in the legacy `containers` dict so existing code
             # (debug endpoints, container_id lookups) still works.
             self.containers[cache_key] = container_id
+            # Mark busy before returning — same rationale as the cache-
+            # hit path. The caller's `finally` pairs it with _mark_idle.
+            self._mark_busy(container_id)
             return container_id, host, host_port
 
     def _exec_via_worker(
@@ -536,6 +832,7 @@ USER codeuser
         code: str,
         env_vars: Dict[str, str],
         timeout_ms: int,
+        token: Optional[str] = None,
     ) -> Tuple[bool, Optional[str], Optional[str], bool]:
         """POST code to the worker; return (success, stdout, stderr, timed_out).
 
@@ -549,10 +846,14 @@ USER codeuser
         # small slack buffer so the server can surface a timed_out=True
         # response rather than us hanging up.
         http_timeout = max(1.0, timeout_ms / 1000.0 + 5.0)
+        headers = {}
+        if token:
+            headers["X-Supakiln-Token"] = token
         try:
             r = self._http.post(
                 url,
                 json={"code": code, "env": env_vars or {}, "timeout_ms": timeout_ms},
+                headers=headers,
                 timeout=http_timeout,
             )
         except requests.ConnectionError as e:
@@ -778,6 +1079,7 @@ USER codeuser
         timeout: int = 30,
         env_vars: Dict[str, str] = None,
         language: str = "python",
+        user_id: int = 1,
     ) -> Dict:
         """
         Execute code in a container with the specified packages.
@@ -789,6 +1091,12 @@ USER codeuser
             env_vars: Dictionary of environment variables to pass to the container
             language: Runtime to use (default "python"). Must be registered
                       in the `languages` module.
+            user_id: Owner of this execution. Used as part of the worker
+                     cache key, so each user runs in their own container
+                     for a given (language, packages). Defaults to the
+                     system user (id=1) — callers that haven't been
+                     wired through the auth layer yet will all share it,
+                     which matches the pre-auth behaviour.
 
         Returns:
             Dict containing execution results
@@ -1130,18 +1438,35 @@ export PYTHONPATH=/tmp:$PYTHONPATH
                 }
 
             package_hash = self._get_package_hash(packages)
-            cache_key = f"{runtime.name}:{package_hash}"
+            cache_key = f"{runtime.name}:u{user_id}:{package_hash}"
 
             # We allow one automatic retry if the cached worker turns out
             # to be dead — that's the self-heal path. A second consecutive
             # unreachable worker is reported to the caller.
+            #
+            # Lease/busy protocol: `_get_or_create_worker_container`
+            # marks the returned container busy on our behalf. We must
+            # pair that with exactly one `_mark_idle` per attempt,
+            # regardless of which branch we exit through (success,
+            # user-code failure, timeout, or self-heal reconstruction).
             last_unreachable: Optional[WorkerUnreachableError] = None
             container_id: Optional[str] = None
             for attempt in range(2):
                 try:
                     container_id, host, port = self._get_or_create_worker_container(
-                        runtime, packages, timings,
+                        runtime, packages, timings, user_id,
                     )
+                except WorkerCapError as e:
+                    # Cap-induced failure: surface the HTTP status so
+                    # the router can return 429 / 503 instead of 500.
+                    timings['total_ms'] = (perf_counter() - t_start) * 1000
+                    return {
+                        "success": False,
+                        "output": None,
+                        "error": str(e),
+                        "http_status": e.http_status,
+                        "timings_ms": timings,
+                    }
                 except Exception as e:
                     timings['total_ms'] = (perf_counter() - t_start) * 1000
                     return {
@@ -1151,26 +1476,36 @@ export PYTHONPATH=/tmp:$PYTHONPATH
                         "timings_ms": timings,
                     }
 
+                # We now hold a busy lease on `container_id`. Use a
+                # try/finally to guarantee release along every path.
                 t_exec = perf_counter()
+                lease_cid = container_id
                 try:
-                    success, stdout, stderr, timed_out = self._exec_via_worker(
-                        host, port, code, env_vars, timeout_ms=int(timeout * 1000),
-                    )
-                    timings['worker_exec_ms'] = (perf_counter() - t_exec) * 1000
-                    if attempt == 1:
-                        timings['self_heal_recovered'] = 1.0
-                    # Record liveness for lifecycle + idle reaper.
-                    meta = self.worker_meta.get(container_id)
-                    if meta is not None:
-                        meta["last_used"] = time.time()
-                    break
-                except WorkerUnreachableError as e:
-                    last_unreachable = e
-                    timings['worker_exec_ms'] = (perf_counter() - t_exec) * 1000
-                    timings[f'self_heal_attempt_{attempt}'] = 1.0
-                    # Evict the dead worker. Next iteration rebuilds.
-                    self._evict_worker(cache_key, container_id)
-                    container_id = None
+                    meta_for_token = self.worker_meta.get(container_id, {})
+                    try:
+                        success, stdout, stderr, timed_out = self._exec_via_worker(
+                            host, port, code, env_vars,
+                            timeout_ms=int(timeout * 1000),
+                            token=meta_for_token.get("worker_token"),
+                        )
+                        timings['worker_exec_ms'] = (perf_counter() - t_exec) * 1000
+                        if attempt == 1:
+                            timings['self_heal_recovered'] = 1.0
+                        # Record liveness for lifecycle + idle reaper.
+                        meta = self.worker_meta.get(container_id)
+                        if meta is not None:
+                            meta["last_used"] = time.time()
+                        break
+                    except WorkerUnreachableError as e:
+                        last_unreachable = e
+                        timings['worker_exec_ms'] = (perf_counter() - t_exec) * 1000
+                        timings[f'self_heal_attempt_{attempt}'] = 1.0
+                        # Evict the dead worker. Next iteration rebuilds.
+                        self._evict_worker(cache_key, container_id)
+                        container_id = None
+                        # Loop continues to the next attempt.
+                finally:
+                    self._mark_idle(lease_cid)
             else:
                 # Both attempts failed — worker couldn't be reached even
                 # after recreating. Surface a clear error.
@@ -1222,16 +1557,23 @@ export PYTHONPATH=/tmp:$PYTHONPATH
     # Lifecycle API used by the /workers router and the idle reaper.
     # ------------------------------------------------------------------
 
-    def list_workers(self) -> List[Dict]:
-        """Return a snapshot of live ad-hoc workers."""
+    def list_workers(self, user_id: Optional[int] = None) -> List[Dict]:
+        """Return a snapshot of live ad-hoc workers.
+
+        If `user_id` is provided, only that user's workers are returned.
+        Admins should pass None to see every container.
+        """
         out: List[Dict] = []
         for container_id, meta in list(self.worker_meta.items()):
+            if user_id is not None and meta.get("user_id") != user_id:
+                continue
             endpoint = self.worker_endpoints.get(container_id)
             out.append({
                 "container_id": container_id,
                 "language": meta["language"],
                 "package_hash": meta["package_hash"],
                 "cache_key": meta["cache_key"],
+                "user_id": meta.get("user_id"),
                 "created_at": meta["created_at"],
                 "last_used": meta["last_used"],
                 "host": endpoint[0] if endpoint else None,

--- a/db_models.py
+++ b/db_models.py
@@ -18,7 +18,7 @@ class EnvironmentVariable(Base):
 
 class ScheduledJob(Base):
     __tablename__ = "scheduled_jobs"
-    
+
     id = Column(Integer, primary_key=True)
     name = Column(String(100), nullable=False)
     code = Column(Text, nullable=False)
@@ -29,10 +29,11 @@ class ScheduledJob(Base):
     last_run = Column(DateTime)
     is_active = Column(Integer, default=1)  # 1 for active, 0 for inactive
     timeout = Column(Integer, default=30)  # Timeout in seconds
+    language = Column(String(20), default="python")
 
 class WebhookJob(Base):
     __tablename__ = "webhook_jobs"
-    
+
     id = Column(Integer, primary_key=True)
     name = Column(String(100), nullable=False)
     endpoint = Column(String(200), unique=True, nullable=False)  # URL path like /webhook/my-job
@@ -44,10 +45,11 @@ class WebhookJob(Base):
     is_active = Column(Integer, default=1)  # 1 for active, 0 for inactive
     timeout = Column(Integer, default=30)  # Timeout in seconds
     description = Column(Text)  # Optional description
+    language = Column(String(20), default="python")
 
 class PersistentService(Base):
     __tablename__ = "persistent_services"
-    
+
     id = Column(Integer, primary_key=True)
     name = Column(String(100), nullable=False)
     code = Column(Text, nullable=False)
@@ -62,6 +64,7 @@ class PersistentService(Base):
     description = Column(Text)  # Optional description
     process_id = Column(String(100))  # Docker exec process ID for running services
     auto_start = Column(Integer, default=1)  # 1 to auto-start on system startup
+    language = Column(String(20), default="python")
 
 class ExposedPort(Base):
     __tablename__ = "exposed_ports"

--- a/db_models.py
+++ b/db_models.py
@@ -1,4 +1,4 @@
-from sqlalchemy import Column, Integer, String, DateTime, Text, Float, create_engine
+from sqlalchemy import Column, Integer, String, DateTime, Text, Float, ForeignKey, create_engine
 from sqlalchemy.ext.declarative import declarative_base
 from sqlalchemy.orm import sessionmaker
 from datetime import datetime
@@ -6,13 +6,58 @@ import os
 
 Base = declarative_base()
 
+
+# The `system` user is the default owner for rows created before auth
+# existed, and the attribution target for any unauthenticated request
+# while SUPAKILN_ALLOW_ANONYMOUS=true (transition period). id=1 is
+# reserved for it by the migration.
+SYSTEM_USER_ID = 1
+
+
+class User(Base):
+    __tablename__ = "users"
+
+    id = Column(Integer, primary_key=True)
+    email = Column(String(255), unique=True, nullable=False)
+    # argon2 hash; NULL for the `system` pseudo-user (cannot log in).
+    password_hash = Column(Text)
+    is_admin = Column(Integer, default=0, nullable=False)
+    disabled = Column(Integer, default=0, nullable=False)
+    created_at = Column(DateTime, default=datetime.utcnow)
+
+
+class ApiKey(Base):
+    __tablename__ = "api_keys"
+
+    id = Column(Integer, primary_key=True)
+    user_id = Column(Integer, ForeignKey("users.id"), nullable=False)
+    # sha256 of the full token (hex). The plaintext is returned exactly
+    # once at creation and never stored.
+    hashed_key = Column(String(64), unique=True, nullable=False)
+    # First 12 chars of the plaintext token (e.g. "supa_ABCDEFG"),
+    # safe to show in listings.
+    prefix = Column(String(32), nullable=False)
+    label = Column(String(100))
+    # "api" (long-lived, user-managed) or "session" (login-issued,
+    # shorter-lived, not user-CRUD-able).
+    kind = Column(String(20), default="api", nullable=False)
+    expires_at = Column(DateTime)  # NULL => never expires
+    last_used_at = Column(DateTime)
+    revoked_at = Column(DateTime)
+    created_at = Column(DateTime, default=datetime.utcnow)
+
+
 class EnvironmentVariable(Base):
     __tablename__ = "environment_variables"
-    
+
     id = Column(Integer, primary_key=True)
-    name = Column(String(100), unique=True, nullable=False)
+    # name is unique PER user (composite unique in the SQL schema), not
+    # globally, so alice and bob can both have a SECRET_KEY. See the v10
+    # migration.
+    name = Column(String(100), nullable=False)
     value = Column(Text, nullable=False)  # Encrypted value
     description = Column(Text)  # Optional description
+    owner_user_id = Column(Integer, ForeignKey("users.id"))
     created_at = Column(DateTime, default=datetime.utcnow)
     updated_at = Column(DateTime, default=datetime.utcnow, onupdate=datetime.utcnow)
 
@@ -25,6 +70,7 @@ class ScheduledJob(Base):
     cron_expression = Column(String(100), nullable=False)
     container_id = Column(String(100))
     packages = Column(Text)  # Stored as comma-separated string
+    owner_user_id = Column(Integer, ForeignKey("users.id"))
     created_at = Column(DateTime, default=datetime.utcnow)
     last_run = Column(DateTime)
     is_active = Column(Integer, default=1)  # 1 for active, 0 for inactive
@@ -40,6 +86,7 @@ class WebhookJob(Base):
     code = Column(Text, nullable=False)
     container_id = Column(String(100))
     packages = Column(Text)  # Stored as comma-separated string
+    owner_user_id = Column(Integer, ForeignKey("users.id"))
     created_at = Column(DateTime, default=datetime.utcnow)
     last_triggered = Column(DateTime)
     is_active = Column(Integer, default=1)  # 1 for active, 0 for inactive
@@ -55,6 +102,7 @@ class PersistentService(Base):
     code = Column(Text, nullable=False)
     container_id = Column(String(100))
     packages = Column(Text)  # Stored as comma-separated string
+    owner_user_id = Column(Integer, ForeignKey("users.id"))
     created_at = Column(DateTime, default=datetime.utcnow)
     started_at = Column(DateTime)
     last_restart = Column(DateTime)
@@ -83,11 +131,12 @@ class ExposedPort(Base):
 
 class ExecutionLog(Base):
     __tablename__ = "execution_logs"
-    
+
     id = Column(Integer, primary_key=True)
     job_id = Column(Integer)  # Null for manual executions
     webhook_job_id = Column(Integer)  # For webhook job executions
     service_id = Column(Integer)  # For persistent service executions
+    owner_user_id = Column(Integer, ForeignKey("users.id"))
     code = Column(Text, nullable=False)
     output = Column(Text)
     error = Column(Text)

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -63,6 +63,30 @@ services:
       - SUPAKILN_WORKER_IDLE_TTL_SECONDS=${SUPAKILN_WORKER_IDLE_TTL_SECONDS:-1800}
       - SUPAKILN_WORKER_REAPER_INTERVAL_SECONDS=${SUPAKILN_WORKER_REAPER_INTERVAL_SECONDS:-60}
       - SUPAKILN_CONTAINER_TMPFS_SIZE=${SUPAKILN_CONTAINER_TMPFS_SIZE:-128m}
+      # Caps. MAX_WORKERS is the global ceiling; MAX_WORKERS_PER_USER
+      # keeps one tenant from monopolising. Exceeding a cap triggers
+      # synchronous LRU eviction of an idle worker; if none are idle,
+      # /execute returns 429 (per-user) or 503 (global).
+      - SUPAKILN_MAX_WORKERS=${SUPAKILN_MAX_WORKERS:-50}
+      - SUPAKILN_MAX_WORKERS_PER_USER=${SUPAKILN_MAX_WORKERS_PER_USER:-5}
+      # Background pressure reaper. Reads host /proc/meminfo + loadavg
+      # and evicts LRU idle workers when either is above its high water.
+      # Set interval to 0 to disable.
+      - SUPAKILN_PRESSURE_REAPER_INTERVAL_SECONDS=${SUPAKILN_PRESSURE_REAPER_INTERVAL_SECONDS:-30}
+      - SUPAKILN_MEMORY_HIGH_WATER_PCT=${SUPAKILN_MEMORY_HIGH_WATER_PCT:-85}
+      - SUPAKILN_MEMORY_LOW_WATER_PCT=${SUPAKILN_MEMORY_LOW_WATER_PCT:-70}
+      # CPU high water is a 1-minute load average. Default = nproc * 1.5
+      # in code if this is unset.
+      - SUPAKILN_CPU_HIGH_WATER=${SUPAKILN_CPU_HIGH_WATER:-}
+      # Auth — first admin is created from these on startup if no
+      # admin exists yet. Leaving both unset skips bootstrap.
+      - SUPAKILN_BOOTSTRAP_ADMIN_EMAIL=${SUPAKILN_BOOTSTRAP_ADMIN_EMAIL:-}
+      - SUPAKILN_BOOTSTRAP_ADMIN_PASSWORD=${SUPAKILN_BOOTSTRAP_ADMIN_PASSWORD:-}
+      # While true (default during transition), unauthenticated requests
+      # are attributed to the system user instead of being rejected.
+      # Flip to false once all clients send bearer tokens or session
+      # cookies.
+      - SUPAKILN_ALLOW_ANONYMOUS=${SUPAKILN_ALLOW_ANONYMOUS:-true}
     depends_on:
       docker-daemon:
         condition: service_healthy 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -59,6 +59,10 @@ services:
       - ENVIRONMENT=${ENVIRONMENT:-production}
       # Container security settings
       - CONTAINER_NETWORK_MODE=${CONTAINER_NETWORK_MODE:-none}  # 'none' for isolation, 'bridge' for network access
+      # Worker lifecycle tuning — see README/docs.
+      - SUPAKILN_WORKER_IDLE_TTL_SECONDS=${SUPAKILN_WORKER_IDLE_TTL_SECONDS:-1800}
+      - SUPAKILN_WORKER_REAPER_INTERVAL_SECONDS=${SUPAKILN_WORKER_REAPER_INTERVAL_SECONDS:-60}
+      - SUPAKILN_CONTAINER_TMPFS_SIZE=${SUPAKILN_CONTAINER_TMPFS_SIZE:-128m}
     depends_on:
       docker-daemon:
         condition: service_healthy 

--- a/dockerfiles/bash.Dockerfile
+++ b/dockerfiles/bash.Dockerfile
@@ -11,8 +11,10 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 
 RUN getent passwd 1000 >/dev/null 2>&1 || useradd -m -u 1000 codeuser
 
-RUN mkdir -p /opt/supakiln && chown -R 1000:1000 /opt/supakiln
-COPY --chown=1000:1000 workers/worker.py /opt/supakiln/worker.py
+RUN mkdir -p /opt/supakiln && chmod 0755 /opt/supakiln
+
+COPY workers/worker.py /opt/supakiln/worker.py
+RUN chmod 0644 /opt/supakiln/worker.py
 
 ENV SUPAKILN_RUN_CMD="bash {file}"
 ENV SUPAKILN_FILE_EXT=".sh"

--- a/dockerfiles/bash.Dockerfile
+++ b/dockerfiles/bash.Dockerfile
@@ -1,0 +1,25 @@
+FROM debian:bookworm-slim
+
+# bash is already present; add python3 for the worker and common CLI
+# tools users are likely to shell out to.
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    python3 \
+    ca-certificates \
+    curl \
+    jq \
+    && rm -rf /var/lib/apt/lists/*
+
+RUN getent passwd 1000 >/dev/null 2>&1 || useradd -m -u 1000 codeuser
+
+RUN mkdir -p /opt/supakiln && chown -R 1000:1000 /opt/supakiln
+COPY --chown=1000:1000 workers/worker.py /opt/supakiln/worker.py
+
+ENV SUPAKILN_RUN_CMD="bash {file}"
+ENV SUPAKILN_FILE_EXT=".sh"
+
+USER 1000
+WORKDIR /tmp
+
+EXPOSE 9999
+
+CMD ["python3", "/opt/supakiln/worker.py"]

--- a/dockerfiles/go.Dockerfile
+++ b/dockerfiles/go.Dockerfile
@@ -9,13 +9,18 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 
 RUN getent passwd 1000 >/dev/null 2>&1 || useradd -m -u 1000 codeuser
 
-RUN mkdir -p /opt/supakiln && chown -R 1000:1000 /opt/supakiln
-COPY --chown=1000:1000 workers/worker.py /opt/supakiln/worker.py
+RUN mkdir -p /opt/supakiln && chmod 0755 /opt/supakiln
 
-# Writable GOCACHE and GOPATH so `go run` works as UID 1000.
+COPY workers/worker.py /opt/supakiln/worker.py
+RUN chmod 0644 /opt/supakiln/worker.py
+
+# GOCACHE / GOPATH under /tmp so `go run` as UID 1000 can write them.
+# /tmp is the tmpfs mount added at container run, so this gives Go a
+# clean scratchpad per container and doesn't persist compile state
+# across restarts — intentional v1, a code-hash compile cache is the
+# follow-up.
 ENV GOCACHE=/tmp/.go-build
 ENV GOPATH=/tmp/.go
-RUN mkdir -p $GOCACHE $GOPATH && chown -R 1000:1000 $GOCACHE $GOPATH
 
 ENV SUPAKILN_RUN_CMD="go run {file}"
 ENV SUPAKILN_FILE_EXT=".go"

--- a/dockerfiles/go.Dockerfile
+++ b/dockerfiles/go.Dockerfile
@@ -1,0 +1,28 @@
+FROM golang:1.22-bookworm
+
+# Python hosts the worker. Go's compile toolchain stays as the image base
+# so `go run`/`go build` inside the container is fast (no Go download per
+# execution).
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    python3 \
+    && rm -rf /var/lib/apt/lists/*
+
+RUN getent passwd 1000 >/dev/null 2>&1 || useradd -m -u 1000 codeuser
+
+RUN mkdir -p /opt/supakiln && chown -R 1000:1000 /opt/supakiln
+COPY --chown=1000:1000 workers/worker.py /opt/supakiln/worker.py
+
+# Writable GOCACHE and GOPATH so `go run` works as UID 1000.
+ENV GOCACHE=/tmp/.go-build
+ENV GOPATH=/tmp/.go
+RUN mkdir -p $GOCACHE $GOPATH && chown -R 1000:1000 $GOCACHE $GOPATH
+
+ENV SUPAKILN_RUN_CMD="go run {file}"
+ENV SUPAKILN_FILE_EXT=".go"
+
+USER 1000
+WORKDIR /tmp
+
+EXPOSE 9999
+
+CMD ["python3", "/opt/supakiln/worker.py"]

--- a/dockerfiles/go.Dockerfile
+++ b/dockerfiles/go.Dockerfile
@@ -14,13 +14,18 @@ RUN mkdir -p /opt/supakiln && chmod 0755 /opt/supakiln
 COPY workers/worker.py /opt/supakiln/worker.py
 RUN chmod 0644 /opt/supakiln/worker.py
 
-# GOCACHE / GOPATH under /tmp so `go run` as UID 1000 can write them.
-# /tmp is the tmpfs mount added at container run, so this gives Go a
-# clean scratchpad per container and doesn't persist compile state
-# across restarts — intentional v1, a code-hash compile cache is the
-# follow-up.
-ENV GOCACHE=/tmp/.go-build
-ENV GOPATH=/tmp/.go
+# Go needs three writable directories that must be on an exec filesystem:
+#   GOCACHE   compile cache
+#   GOPATH    module cache + bin
+#   GOTMPDIR  the work dir `go run` creates and exec()s the linked binary
+#             from (defaults to $TMPDIR or /tmp). Our /tmp is a docker
+#             --tmpfs mount that defaults to noexec, so without GOTMPDIR
+#             `go run` fails with "fork/exec: permission denied" on its
+#             own output.
+ENV GOCACHE=/home/codeuser/.cache/go-build
+ENV GOPATH=/home/codeuser/go
+ENV GOTMPDIR=/home/codeuser/.gotmp
+RUN mkdir -p $GOCACHE $GOPATH $GOTMPDIR && chown -R 1000:1000 /home/codeuser
 
 ENV SUPAKILN_RUN_CMD="go run {file}"
 ENV SUPAKILN_FILE_EXT=".go"

--- a/dockerfiles/node.Dockerfile
+++ b/dockerfiles/node.Dockerfile
@@ -1,0 +1,25 @@
+FROM node:20-slim
+
+# Python is the worker runtime. It's a small addition (~20MB) and keeps
+# worker maintenance to one implementation across all languages.
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    python3 \
+    && rm -rf /var/lib/apt/lists/*
+
+# node:20-slim already ships a `node` user at UID 1000 — reuse it.
+RUN getent passwd 1000 >/dev/null 2>&1 || useradd -m -u 1000 codeuser
+
+RUN mkdir -p /opt/supakiln/pkgs && chown -R 1000:1000 /opt/supakiln
+COPY --chown=1000:1000 workers/worker.py /opt/supakiln/worker.py
+
+# User code requires('pkg') resolves via NODE_PATH → installed packages.
+ENV NODE_PATH="/opt/supakiln/pkgs/node_modules"
+ENV SUPAKILN_RUN_CMD="node {file}"
+ENV SUPAKILN_FILE_EXT=".js"
+
+USER 1000
+WORKDIR /tmp
+
+EXPOSE 9999
+
+CMD ["python3", "/opt/supakiln/worker.py"]

--- a/dockerfiles/node.Dockerfile
+++ b/dockerfiles/node.Dockerfile
@@ -9,8 +9,13 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 # node:20-slim already ships a `node` user at UID 1000 — reuse it.
 RUN getent passwd 1000 >/dev/null 2>&1 || useradd -m -u 1000 codeuser
 
-RUN mkdir -p /opt/supakiln/pkgs && chown -R 1000:1000 /opt/supakiln
-COPY --chown=1000:1000 workers/worker.py /opt/supakiln/worker.py
+# /opt/supakiln is root-owned world-readable (+x for dir, 0644 for files)
+# so user code as UID 1000 can read but not modify worker.py or the
+# installed npm packages.
+RUN mkdir -p /opt/supakiln/pkgs && chmod 0755 /opt/supakiln /opt/supakiln/pkgs
+
+COPY workers/worker.py /opt/supakiln/worker.py
+RUN chmod 0644 /opt/supakiln/worker.py
 
 # User code requires('pkg') resolves via NODE_PATH → installed packages.
 ENV NODE_PATH="/opt/supakiln/pkgs/node_modules"

--- a/dockerfiles/python.Dockerfile
+++ b/dockerfiles/python.Dockerfile
@@ -1,0 +1,19 @@
+FROM python:3.12-slim
+
+ENV PYTHONUNBUFFERED=1
+ENV PYTHONDONTWRITEBYTECODE=1
+
+# Non-root execution user (matches --user 1000:1000 from CodeExecutor).
+RUN useradd -m -u 1000 codeuser
+
+# Worker lives at a fixed path inside the image.
+RUN mkdir -p /opt/supakiln && chown -R codeuser:codeuser /opt/supakiln
+
+COPY --chown=codeuser:codeuser workers/python/worker.py /opt/supakiln/worker.py
+
+USER codeuser
+WORKDIR /tmp
+
+EXPOSE 9999
+
+CMD ["python3", "/opt/supakiln/worker.py"]

--- a/dockerfiles/python.Dockerfile
+++ b/dockerfiles/python.Dockerfile
@@ -6,10 +6,12 @@ ENV PYTHONDONTWRITEBYTECODE=1
 # Non-root execution user (matches --user 1000:1000 from CodeExecutor).
 RUN getent passwd 1000 >/dev/null 2>&1 || useradd -m -u 1000 codeuser
 
-# Worker lives at a fixed path inside the image.
-RUN mkdir -p /opt/supakiln && chown -R 1000:1000 /opt/supakiln
+# /opt/supakiln is root-owned world-readable so user code running as
+# UID 1000 can read worker.py but cannot delete or overwrite it.
+RUN mkdir -p /opt/supakiln && chmod 0755 /opt/supakiln
 
-COPY --chown=1000:1000 workers/worker.py /opt/supakiln/worker.py
+COPY workers/worker.py /opt/supakiln/worker.py
+RUN chmod 0644 /opt/supakiln/worker.py
 
 ENV SUPAKILN_RUN_CMD="python3 {file}"
 ENV SUPAKILN_FILE_EXT=".py"

--- a/dockerfiles/ruby.Dockerfile
+++ b/dockerfiles/ruby.Dockerfile
@@ -6,8 +6,10 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 
 RUN getent passwd 1000 >/dev/null 2>&1 || useradd -m -u 1000 codeuser
 
-RUN mkdir -p /opt/supakiln && chown -R 1000:1000 /opt/supakiln
-COPY --chown=1000:1000 workers/worker.py /opt/supakiln/worker.py
+RUN mkdir -p /opt/supakiln && chmod 0755 /opt/supakiln
+
+COPY workers/worker.py /opt/supakiln/worker.py
+RUN chmod 0644 /opt/supakiln/worker.py
 
 ENV SUPAKILN_RUN_CMD="ruby {file}"
 ENV SUPAKILN_FILE_EXT=".rb"

--- a/dockerfiles/ruby.Dockerfile
+++ b/dockerfiles/ruby.Dockerfile
@@ -1,18 +1,16 @@
-FROM python:3.12-slim
+FROM ruby:3.3-slim
 
-ENV PYTHONUNBUFFERED=1
-ENV PYTHONDONTWRITEBYTECODE=1
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    python3 \
+    && rm -rf /var/lib/apt/lists/*
 
-# Non-root execution user (matches --user 1000:1000 from CodeExecutor).
 RUN getent passwd 1000 >/dev/null 2>&1 || useradd -m -u 1000 codeuser
 
-# Worker lives at a fixed path inside the image.
 RUN mkdir -p /opt/supakiln && chown -R 1000:1000 /opt/supakiln
-
 COPY --chown=1000:1000 workers/worker.py /opt/supakiln/worker.py
 
-ENV SUPAKILN_RUN_CMD="python3 {file}"
-ENV SUPAKILN_FILE_EXT=".py"
+ENV SUPAKILN_RUN_CMD="ruby {file}"
+ENV SUPAKILN_FILE_EXT=".rb"
 
 USER 1000
 WORKDIR /tmp

--- a/env_manager.py
+++ b/env_manager.py
@@ -1,23 +1,32 @@
 from cryptography.fernet import Fernet
-from sqlalchemy import Column, Integer, String, DateTime
-from sqlalchemy.ext.declarative import declarative_base
 from datetime import datetime
 import os
-import base64
 
-Base = declarative_base()
+# Canonical model + SYSTEM_USER_ID live in db_models; re-import locally so
+# the manager always operates on the same table definition the rest of
+# the app uses (the old duplicate class here caused table-redefinition
+# headaches).
+from db_models import EnvironmentVariable, SYSTEM_USER_ID
 
-class EnvironmentVariable(Base):
-    __tablename__ = "environment_variables"
-    
-    id = Column(Integer, primary_key=True)
-    name = Column(String, unique=True, nullable=False)
-    value = Column(String, nullable=False)  # Encrypted value
-    description = Column(String)  # Optional description
-    created_at = Column(DateTime, default=datetime.utcnow)
-    updated_at = Column(DateTime, default=datetime.utcnow, onupdate=datetime.utcnow)
 
 class EnvironmentManager:
+    """Per-user Fernet-encrypted environment variables.
+
+    Every mutator and reader takes `owner_user_id`. This keeps one user's
+    secrets out of another's `get_all_variables()` result, which is what
+    gets injected into the container on `/execute`. Unique key on
+    `name` is per-user (composite, enforced in SQL with `_scoped_query`).
+
+    NOTE: the old schema had `UNIQUE(name)` globally. The v9 migration
+    added `owner_user_id` but left the unique constraint on `name`
+    alone — that's a footgun if two different users want a `SECRET_KEY`
+    variable. The variable model still has `unique=True` on `name`; we
+    work around it by scoping lookups, but a future migration should
+    drop that unique constraint and add a composite unique on
+    `(owner_user_id, name)`. For now, names remain global across users
+    and set_variable will raise on conflict.
+    """
+
     def __init__(self, db_session, encryption_key=None):
         self.db = db_session
         if encryption_key:
@@ -30,11 +39,24 @@ class EnvironmentManager:
             with open('.env_key', 'wb') as key_file:
                 key_file.write(key)
 
-    def set_variable(self, name: str, value: str, description: str = None) -> None:
+    def _scoped_query(self, owner_user_id: int):
+        return self.db.query(EnvironmentVariable).filter(
+            EnvironmentVariable.owner_user_id == owner_user_id
+        )
+
+    def set_variable(
+        self,
+        name: str,
+        value: str,
+        owner_user_id: int = SYSTEM_USER_ID,
+        description: str = None,
+    ) -> None:
         """Set an environment variable with encryption."""
         encrypted_value = self.fernet.encrypt(value.encode())
-        var = self.db.query(EnvironmentVariable).filter_by(name=name).first()
-        
+        var = self._scoped_query(owner_user_id).filter(
+            EnvironmentVariable.name == name
+        ).first()
+
         if var:
             var.value = encrypted_value.decode()
             var.updated_at = datetime.utcnow()
@@ -44,69 +66,89 @@ class EnvironmentManager:
             var = EnvironmentVariable(
                 name=name,
                 value=encrypted_value.decode(),
-                description=description
+                description=description,
+                owner_user_id=owner_user_id,
             )
             self.db.add(var)
-        
+
         self.db.commit()
 
-    def get_variable(self, name: str) -> str:
+    def get_variable(self, name: str, owner_user_id: int = SYSTEM_USER_ID) -> str:
         """Get a decrypted environment variable value."""
-        var = self.db.query(EnvironmentVariable).filter_by(name=name).first()
+        var = self._scoped_query(owner_user_id).filter(
+            EnvironmentVariable.name == name
+        ).first()
         if not var:
             return None
-        
+
         try:
             decrypted_value = self.fernet.decrypt(var.value.encode())
             return decrypted_value.decode()
         except Exception:
             return None
 
-    def get_variable_metadata(self, name: str) -> dict:
+    def get_variable_metadata(
+        self, name: str, owner_user_id: int = SYSTEM_USER_ID
+    ) -> dict:
         """Get environment variable metadata without the value."""
-        var = self.db.query(EnvironmentVariable).filter_by(name=name).first()
+        var = self._scoped_query(owner_user_id).filter(
+            EnvironmentVariable.name == name
+        ).first()
         if not var:
             return None
-        
+
         return {
             "name": var.name,
             "description": var.description,
             "created_at": var.created_at.isoformat(),
-            "updated_at": var.updated_at.isoformat()
+            "updated_at": var.updated_at.isoformat(),
         }
 
-    def list_variables_with_metadata(self) -> list:
+    def list_variables_with_metadata(
+        self, owner_user_id: int = SYSTEM_USER_ID
+    ) -> list:
         """List all environment variables with metadata but without values."""
         variables = []
-        for var in self.db.query(EnvironmentVariable).all():
+        for var in self._scoped_query(owner_user_id).all():
             variables.append({
                 "name": var.name,
                 "description": var.description,
                 "created_at": var.created_at.isoformat(),
-                "updated_at": var.updated_at.isoformat()
+                "updated_at": var.updated_at.isoformat(),
             })
         return variables
 
-    def delete_variable(self, name: str) -> bool:
+    def delete_variable(
+        self, name: str, owner_user_id: int = SYSTEM_USER_ID
+    ) -> bool:
         """Delete an environment variable."""
-        var = self.db.query(EnvironmentVariable).filter_by(name=name).first()
+        var = self._scoped_query(owner_user_id).filter(
+            EnvironmentVariable.name == name
+        ).first()
         if var:
             self.db.delete(var)
             self.db.commit()
             return True
         return False
 
-    def list_variables(self) -> list:
+    def list_variables(self, owner_user_id: int = SYSTEM_USER_ID) -> list:
         """List all environment variable names."""
-        return [var.name for var in self.db.query(EnvironmentVariable).all()]
+        return [var.name for var in self._scoped_query(owner_user_id).all()]
 
-    def get_all_variables(self) -> dict:
-        """Get all environment variables as a dictionary."""
+    def get_all_variables(
+        self, owner_user_id: int = SYSTEM_USER_ID
+    ) -> dict:
+        """Get all environment variables as a dictionary.
+
+        Call this with the executing user's id; the returned dict is what
+        the executor injects into the container. Any leak here crosses
+        the per-user isolation boundary.
+        """
         variables = {}
-        for var in self.db.query(EnvironmentVariable).all():
+        for var in self._scoped_query(owner_user_id).all():
             try:
                 decrypted_value = self.fernet.decrypt(var.value.encode())
                 variables[var.name] = decrypted_value.decode()
             except Exception:
                 continue
-        return variables 
+        return variables

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -9,6 +9,7 @@ import Logs from './pages/Logs';
 import SavedCode from './pages/Containers';
 import RunningContainers from './pages/RunningContainers';
 import EnvironmentVariables from './pages/EnvironmentVariables';
+import Workers from './pages/Workers';
 
 const theme = createTheme({
   palette: {
@@ -34,6 +35,7 @@ function App() {
             <Route path="/containers" element={<RunningContainers />} />
             <Route path="/scheduler" element={<Scheduler />} />
             <Route path="/webhooks" element={<WebhookJobs />} />
+            <Route path="/workers" element={<Workers />} />
             <Route path="/logs" element={<Logs />} />
             <Route path="/env" element={<EnvironmentVariables />} />
           </Routes>

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -10,6 +10,11 @@ import SavedCode from './pages/Containers';
 import RunningContainers from './pages/RunningContainers';
 import EnvironmentVariables from './pages/EnvironmentVariables';
 import Workers from './pages/Workers';
+import Login from './pages/Login';
+import ApiKeys from './pages/ApiKeys';
+import AdminUsers from './pages/AdminUsers';
+import { AuthProvider } from './auth/AuthContext';
+import AuthGuard from './auth/AuthGuard';
 
 const theme = createTheme({
   palette: {
@@ -28,21 +33,43 @@ function App() {
     <ThemeProvider theme={theme}>
       <CssBaseline />
       <Router>
-        <Layout>
+        <AuthProvider>
           <Routes>
-            <Route path="/" element={<Editor />} />
-            <Route path="/saved-code" element={<SavedCode />} />
-            <Route path="/containers" element={<RunningContainers />} />
-            <Route path="/scheduler" element={<Scheduler />} />
-            <Route path="/webhooks" element={<WebhookJobs />} />
-            <Route path="/workers" element={<Workers />} />
-            <Route path="/logs" element={<Logs />} />
-            <Route path="/env" element={<EnvironmentVariables />} />
+            {/* Login lives outside the guard + Layout so an unauthed
+                user can reach it without bouncing. */}
+            <Route path="/login" element={<Login />} />
+
+            {/* Everything else is gated. If the backend is in strict
+                mode (SUPAKILN_ALLOW_ANONYMOUS=false) and there's no
+                token, the guard redirects to /login. In anonymous mode
+                /auth/me succeeds for the system user and the app
+                renders as-is. */}
+            <Route
+              path="/*"
+              element={
+                <AuthGuard>
+                  <Layout>
+                    <Routes>
+                      <Route path="/" element={<Editor />} />
+                      <Route path="/saved-code" element={<SavedCode />} />
+                      <Route path="/containers" element={<RunningContainers />} />
+                      <Route path="/scheduler" element={<Scheduler />} />
+                      <Route path="/webhooks" element={<WebhookJobs />} />
+                      <Route path="/workers" element={<Workers />} />
+                      <Route path="/logs" element={<Logs />} />
+                      <Route path="/env" element={<EnvironmentVariables />} />
+                      <Route path="/keys" element={<ApiKeys />} />
+                      <Route path="/admin/users" element={<AdminUsers />} />
+                    </Routes>
+                  </Layout>
+                </AuthGuard>
+              }
+            />
           </Routes>
-        </Layout>
+        </AuthProvider>
       </Router>
     </ThemeProvider>
   );
 }
 
-export default App; 
+export default App;

--- a/frontend/src/auth/AuthContext.tsx
+++ b/frontend/src/auth/AuthContext.tsx
@@ -1,0 +1,122 @@
+import React, {
+  createContext,
+  useCallback,
+  useContext,
+  useEffect,
+  useMemo,
+  useState,
+} from 'react';
+import {
+  api,
+  getToken,
+  setToken,
+  clearToken,
+  AUTH_UNAUTHORIZED_EVENT,
+} from '../config/api';
+
+export interface AuthUser {
+  id: number;
+  email: string;
+  is_admin: boolean;
+  disabled: boolean;
+  created_at: string;
+}
+
+interface AuthState {
+  user: AuthUser | null;
+  // `authRequired` is true once we've seen a 401 from /auth/me — i.e.
+  // the backend is enforcing auth and we're not logged in. The root
+  // guard reads this to decide between "show login" and "show app as
+  // anonymous system user".
+  authRequired: boolean;
+  loading: boolean;
+  login: (email: string, password: string) => Promise<void>;
+  logout: () => Promise<void>;
+  refresh: () => Promise<void>;
+}
+
+const AuthContext = createContext<AuthState | undefined>(undefined);
+
+export const AuthProvider: React.FC<{ children: React.ReactNode }> = ({
+  children,
+}) => {
+  const [user, setUser] = useState<AuthUser | null>(null);
+  const [authRequired, setAuthRequired] = useState(false);
+  const [loading, setLoading] = useState(true);
+
+  const refresh = useCallback(async () => {
+    try {
+      const r = await api.get<AuthUser>('/auth/me');
+      setUser(r.data);
+      setAuthRequired(false);
+    } catch (e: any) {
+      // 401 means either: no token and backend requires auth, or our
+      // token is invalid/expired. Either way, we must show login.
+      if (e?.status === 401 || e?.response?.status === 401) {
+        setUser(null);
+        setAuthRequired(true);
+        // Drop a stale token so the next request doesn't keep failing.
+        if (getToken()) clearToken();
+      } else {
+        // Network or other error — leave user/null and don't force
+        // login, the app will just retry as anonymous.
+        setUser(null);
+        setAuthRequired(false);
+      }
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    refresh();
+  }, [refresh]);
+
+  // If any later request returns 401, the axios interceptor fires this
+  // event. Drop the user and flip to "auth required" so the guard
+  // routes to /login on the next render.
+  useEffect(() => {
+    const handler = () => {
+      setUser(null);
+      setAuthRequired(true);
+    };
+    window.addEventListener(AUTH_UNAUTHORIZED_EVENT, handler);
+    return () => window.removeEventListener(AUTH_UNAUTHORIZED_EVENT, handler);
+  }, []);
+
+  const login = useCallback(async (email: string, password: string) => {
+    const r = await api.post('/auth/login', { email, password });
+    setToken(r.data.session_token);
+    setUser(r.data.user);
+    setAuthRequired(false);
+  }, []);
+
+  const logout = useCallback(async () => {
+    try {
+      await api.post('/auth/logout');
+    } catch {
+      // best-effort server-side; we still wipe client state
+    }
+    clearToken();
+    setUser(null);
+    // After logout, probe /auth/me again — if backend is in anonymous
+    // mode we'll land back on the system user; if it's enforcing, the
+    // guard will route to /login.
+    await refresh();
+  }, [refresh]);
+
+  const value = useMemo(
+    () => ({ user, authRequired, loading, login, logout, refresh }),
+    [user, authRequired, loading, login, logout, refresh],
+  );
+
+  return <AuthContext.Provider value={value}>{children}</AuthContext.Provider>;
+};
+
+export const useAuth = (): AuthState => {
+  const ctx = useContext(AuthContext);
+  if (!ctx) {
+    throw new Error('useAuth must be used inside <AuthProvider>');
+  }
+  return ctx;
+};

--- a/frontend/src/auth/AuthGuard.tsx
+++ b/frontend/src/auth/AuthGuard.tsx
@@ -1,0 +1,50 @@
+import React from 'react';
+import { Navigate, useLocation } from 'react-router-dom';
+import { Box, CircularProgress } from '@mui/material';
+import { useAuth } from './AuthContext';
+
+/**
+ * Wraps the authenticated part of the app.
+ *
+ * Three states from AuthContext drive three outcomes:
+ *
+ *   loading === true       → splash spinner (we're probing /auth/me)
+ *   authRequired === true  → redirect to /login, remember where we
+ *                             came from so login can bounce back
+ *   otherwise              → render children; user is either a real
+ *                             logged-in user or the anonymous system
+ *                             user (SUPAKILN_ALLOW_ANONYMOUS=true)
+ */
+const AuthGuard: React.FC<{ children: React.ReactNode }> = ({ children }) => {
+  const { loading, authRequired } = useAuth();
+  const location = useLocation();
+
+  if (loading) {
+    return (
+      <Box
+        sx={{
+          minHeight: '100vh',
+          display: 'flex',
+          alignItems: 'center',
+          justifyContent: 'center',
+        }}
+      >
+        <CircularProgress />
+      </Box>
+    );
+  }
+
+  if (authRequired) {
+    return (
+      <Navigate
+        to="/login"
+        replace
+        state={{ from: location.pathname + location.search }}
+      />
+    );
+  }
+
+  return <>{children}</>;
+};
+
+export default AuthGuard;

--- a/frontend/src/components/Layout.tsx
+++ b/frontend/src/components/Layout.tsx
@@ -6,6 +6,7 @@ import {
   Typography,
   Container,
   Box,
+  Button,
   IconButton,
   Drawer,
   List,
@@ -13,8 +14,14 @@ import {
   ListItemButton,
   ListItemText,
   Divider,
+  Tooltip,
+  Chip,
 } from '@mui/material';
-import { Menu as MenuIcon } from '@mui/icons-material';
+import {
+  Menu as MenuIcon,
+  Logout as LogoutIcon,
+} from '@mui/icons-material';
+import { useAuth } from '../auth/AuthContext';
 
 interface LayoutProps {
   children: React.ReactNode;
@@ -23,8 +30,25 @@ interface LayoutProps {
 const Layout: React.FC<LayoutProps> = ({ children }) => {
   const navigate = useNavigate();
   const location = useLocation();
+  const { user, logout } = useAuth();
   const [drawerOpen, setDrawerOpen] = useState(false);
 
+  // System user (id=1) is the anonymous-fallback identity; a real
+  // logged-in user has id >= 2. Reflect that in the UI so operators can
+  // tell at a glance whether they're authenticated or riding on the
+  // anonymous-mode convenience.
+  const isAnonymous = !user || user.id === 1;
+
+  const handleLogout = async () => {
+    await logout();
+    // After logout, the guard decides whether to show login or keep
+    // anonymous — we don't hardcode a destination here.
+    navigate('/');
+  };
+
+  // Nav: hide auth-gated items for anonymous users, hide admin items
+  // unless the caller is admin. Keeps the drawer tidy for the common
+  // case.
   const navItems = [
     { path: '/', label: 'Editor' },
     { path: '/saved-code', label: 'Saved Code' },
@@ -34,6 +58,8 @@ const Layout: React.FC<LayoutProps> = ({ children }) => {
     { path: '/workers', label: 'Workers' },
     { path: '/logs', label: 'Logs' },
     { path: '/env', label: 'Environment Variables' },
+    ...(!isAnonymous ? [{ path: '/keys', label: 'API Keys' }] : []),
+    ...(user?.is_admin ? [{ path: '/admin/users', label: 'Admin: Users' }] : []),
   ];
 
   const handleDrawerToggle = () => {
@@ -94,6 +120,48 @@ const Layout: React.FC<LayoutProps> = ({ children }) => {
           <Typography variant="h6" component="div" sx={{ flexGrow: 1, fontSize: '1.1rem' }}>
             Python Code Execution Engine
           </Typography>
+
+          {user && (
+            <Box sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
+              <Tooltip
+                title={
+                  isAnonymous
+                    ? 'Running as the system user (anonymous mode). ' +
+                      'Sign in to get your own isolated containers.'
+                    : user.is_admin
+                      ? 'Signed in as admin'
+                      : 'Signed in'
+                }
+              >
+                <Chip
+                  size="small"
+                  label={isAnonymous ? 'anonymous' : user.email}
+                  color={isAnonymous ? 'default' : user.is_admin ? 'secondary' : 'primary'}
+                  variant={isAnonymous ? 'outlined' : 'filled'}
+                />
+              </Tooltip>
+              {isAnonymous ? (
+                <Button
+                  size="small"
+                  color="inherit"
+                  onClick={() => navigate('/login')}
+                >
+                  Sign in
+                </Button>
+              ) : (
+                <Tooltip title="Sign out">
+                  <IconButton
+                    size="small"
+                    color="inherit"
+                    onClick={handleLogout}
+                    aria-label="sign out"
+                  >
+                    <LogoutIcon fontSize="small" />
+                  </IconButton>
+                </Tooltip>
+              )}
+            </Box>
+          )}
         </Toolbar>
       </AppBar>
       

--- a/frontend/src/components/Layout.tsx
+++ b/frontend/src/components/Layout.tsx
@@ -31,6 +31,7 @@ const Layout: React.FC<LayoutProps> = ({ children }) => {
     { path: '/containers', label: 'Running Containers' },
     { path: '/scheduler', label: 'Scheduler' },
     { path: '/webhooks', label: 'Webhooks' },
+    { path: '/workers', label: 'Workers' },
     { path: '/logs', label: 'Logs' },
     { path: '/env', label: 'Environment Variables' },
   ];

--- a/frontend/src/config/api.ts
+++ b/frontend/src/config/api.ts
@@ -26,6 +26,33 @@ const CF_CLIENT_ID = import.meta.env.VITE_CF_CLIENT_ID;
 const CF_CLIENT_SECRET = import.meta.env.VITE_CF_CLIENT_SECRET;
 const CF_ACCESS_TOKEN = import.meta.env.VITE_CF_ACCESS_TOKEN;
 
+// -------------------------------------------------------------------
+// Supakiln bearer-token auth. Persisted in localStorage so reloads
+// keep the user logged in. The AuthContext is the source of truth for
+// *who* the user is; this module just ferries the token into request
+// headers and clears it on 401.
+// -------------------------------------------------------------------
+
+const TOKEN_STORAGE_KEY = 'supakiln_token';
+
+export function getToken(): string | null {
+  return localStorage.getItem(TOKEN_STORAGE_KEY);
+}
+
+export function setToken(token: string): void {
+  localStorage.setItem(TOKEN_STORAGE_KEY, token);
+}
+
+export function clearToken(): void {
+  localStorage.removeItem(TOKEN_STORAGE_KEY);
+}
+
+// When a response comes back 401 mid-session, we dispatch this event
+// so the AuthContext can react (drop the user, show the login page).
+// Using a browser event avoids a circular import between api.ts and
+// AuthContext.tsx.
+export const AUTH_UNAUTHORIZED_EVENT = 'supakiln:unauthorized';
+
 // Create axios instance with Cloudflare Access configuration
 export const api = axios.create({
   baseURL: API_URL,
@@ -46,10 +73,16 @@ export const api = axios.create({
 // Enhanced request interceptor
 api.interceptors.request.use(
   (config: InternalAxiosRequestConfig) => {
-    // Add dynamic headers
-    const token = localStorage.getItem('cf_access_token');
-    if (token && config.headers) {
-      config.headers['CF-Access-Token'] = token;
+    // Supakiln bearer token (from localStorage via auth context).
+    const supaToken = getToken();
+    if (supaToken && config.headers) {
+      config.headers['Authorization'] = `Bearer ${supaToken}`;
+    }
+
+    // Legacy Cloudflare Access header (if set by the deployment).
+    const cfToken = localStorage.getItem('cf_access_token');
+    if (cfToken && config.headers) {
+      config.headers['CF-Access-Token'] = cfToken;
     }
 
     // Add CSRF token if available
@@ -57,12 +90,6 @@ api.interceptors.request.use(
     if (csrfToken && config.headers) {
       config.headers['X-CSRF-Token'] = csrfToken;
     }
-
-    // Log request for debugging
-    console.log(`Making ${config.method?.toUpperCase()} request to ${config.url}`, {
-      headers: config.headers,
-      hasCloudflareAuth: !!(CF_CLIENT_ID && CF_CLIENT_SECRET),
-    });
 
     return config;
   },
@@ -82,6 +109,18 @@ api.interceptors.response.use(
     if (error.response?.status === 403 && error.response?.headers?.['cf-ray']) {
       console.warn('Cloudflare Access authentication failed');
       // Optionally redirect to Cloudflare Access login or show error message
+    }
+
+    // Supakiln 401: notify the AuthContext so the UI can drop the
+    // user and route to /login. We skip this for /auth/login itself
+    // since that's the user mistyping their password, not a session
+    // problem.
+    if (
+      error.response?.status === 401 &&
+      !(error.config?.url || '').includes('/auth/login')
+    ) {
+      clearToken();
+      window.dispatchEvent(new CustomEvent(AUTH_UNAUTHORIZED_EVENT));
     }
     
     // Enhanced error logging and processing for better frontend error handling

--- a/frontend/src/config/languages.ts
+++ b/frontend/src/config/languages.ts
@@ -1,0 +1,55 @@
+import api from './api';
+
+export interface Runtime {
+  name: string;
+  display_name: string;
+  file_extension: string;
+  supports_packages: boolean;
+  package_manager: string | null;
+}
+
+export interface LanguagesResponse {
+  languages: string[];
+  runtimes: Runtime[];
+}
+
+// Map backend runtime name -> Monaco editor language id
+const MONACO_LANGUAGE_MAP: Record<string, string> = {
+  python: 'python',
+  node: 'javascript',
+  ruby: 'ruby',
+  bash: 'shell',
+  go: 'go',
+};
+
+export const monacoLanguageFor = (runtime: string): string =>
+  MONACO_LANGUAGE_MAP[runtime] || 'plaintext';
+
+export const fetchRuntimes = async (): Promise<Runtime[]> => {
+  const response = await api.get<LanguagesResponse>('/languages');
+  return response.data.runtimes || [];
+};
+
+// Compact human-readable relative time for ISO timestamps. Kept small to
+// avoid pulling in a date library (date-fns is not in the project).
+export const formatRelativeTime = (iso: string | null | undefined): string => {
+  if (!iso) return '-';
+  const then = new Date(iso).getTime();
+  if (Number.isNaN(then)) return iso || '-';
+  const diffSeconds = Math.round((Date.now() - then) / 1000);
+  const abs = Math.abs(diffSeconds);
+  const suffix = diffSeconds >= 0 ? 'ago' : 'from now';
+
+  if (abs < 5) return 'just now';
+  if (abs < 60) return `${abs} second${abs === 1 ? '' : 's'} ${suffix}`;
+  const minutes = Math.round(abs / 60);
+  if (minutes < 60) return `${minutes} minute${minutes === 1 ? '' : 's'} ${suffix}`;
+  const hours = Math.round(abs / 3600);
+  if (hours < 24) return `${hours} hour${hours === 1 ? '' : 's'} ${suffix}`;
+  const days = Math.round(abs / 86400);
+  if (days < 30) return `${days} day${days === 1 ? '' : 's'} ${suffix}`;
+  const months = Math.round(abs / (86400 * 30));
+  if (months < 12) return `${months} month${months === 1 ? '' : 's'} ${suffix}`;
+  const years = Math.round(abs / (86400 * 365));
+  return `${years} year${years === 1 ? '' : 's'} ${suffix}`;
+};

--- a/frontend/src/config/templates.ts
+++ b/frontend/src/config/templates.ts
@@ -1,0 +1,424 @@
+// App templates shown in the Editor. Filtered by the selected runtime so
+// a user picking "Node.js" only sees Node templates.
+//
+// When adding a language template, keep the code SHORT and self-contained
+// and make sure it prints something useful — templates are the fastest
+// way a new dev sanity-checks that their runtime works.
+
+export interface AppTemplate {
+  key: string;
+  name: string;
+  language: string;
+  packages: string[];
+  code: string;
+}
+
+export const APP_TEMPLATES: AppTemplate[] = [
+  // ---------- Python ----------
+  {
+    key: 'python-basic',
+    name: 'Basic Python',
+    language: 'python',
+    packages: [],
+    code: `# Write your Python code here
+import os
+
+database_url = os.getenv('DATABASE_URL', 'sqlite:///default.db')
+print(f"Database URL: {database_url}")
+
+debug_mode = os.getenv('DEBUG', 'false').lower() == 'true'
+print(f"Debug mode: {debug_mode}")
+
+print("Hello, World!")
+`,
+  },
+  {
+    key: 'python-requests',
+    name: 'HTTP + JSON (requests)',
+    language: 'python',
+    packages: ['requests'],
+    code: `import requests
+
+r = requests.get("https://httpbin.org/json")
+data = r.json()
+print("status:", r.status_code)
+print("slideshow title:", data["slideshow"]["title"])
+`,
+  },
+  {
+    key: 'python-gradio',
+    name: 'Gradio App',
+    language: 'python',
+    packages: ['gradio'],
+    code: `import gradio as gr
+
+def greet(name):
+    return f"Hello, {name}!"
+
+with gr.Blocks() as demo:
+    inp = gr.Textbox(label="Your name")
+    out = gr.Textbox(label="Greeting")
+    btn = gr.Button("Greet")
+    btn.click(fn=greet, inputs=inp, outputs=out)
+
+if __name__ == "__main__":
+    demo.launch(server_name="0.0.0.0", server_port=7860)
+`,
+  },
+  {
+    key: 'python-fastapi',
+    name: 'FastAPI App',
+    language: 'python',
+    packages: ['fastapi', 'uvicorn'],
+    code: `from fastapi import FastAPI
+import uvicorn
+
+app = FastAPI(title="My API", description="A simple FastAPI application")
+
+@app.get("/")
+def read_root():
+    return {"message": "Hello World", "status": "running"}
+
+@app.get("/items/{item_id}")
+def read_item(item_id: int, q: str = None):
+    return {"item_id": item_id, "q": q}
+
+@app.get("/health")
+def health_check():
+    return {"status": "healthy"}
+
+if __name__ == "__main__":
+    uvicorn.run(app, host="0.0.0.0", port=8000)
+`,
+  },
+  {
+    key: 'python-flask',
+    name: 'Flask App',
+    language: 'python',
+    packages: ['flask'],
+    code: `from flask import Flask, jsonify, render_template_string
+
+app = Flask(__name__)
+
+HTML_TEMPLATE = '''
+<!DOCTYPE html>
+<html>
+<head>
+    <title>My Flask App</title>
+    <style>
+        body { font-family: Arial, sans-serif; margin: 40px; }
+        .container { max-width: 600px; margin: 0 auto; }
+        h1 { color: #333; }
+        .btn { background: #007bff; color: white; padding: 10px 20px;
+               text-decoration: none; border-radius: 5px; }
+    </style>
+</head>
+<body>
+    <div class="container">
+        <h1>Welcome to My Flask App!</h1>
+        <p>This is a simple Flask application.</p>
+        <a href="/api/data" class="btn">View API Data</a>
+    </div>
+</body>
+</html>
+'''
+
+@app.route('/')
+def home():
+    return render_template_string(HTML_TEMPLATE)
+
+@app.route('/api/data')
+def get_data():
+    return jsonify({
+        "message": "Hello from Flask!",
+        "data": [1, 2, 3, 4, 5],
+        "status": "success"
+    })
+
+if __name__ == '__main__':
+    app.run(host='0.0.0.0', port=5000, debug=True)
+`,
+  },
+  {
+    key: 'python-dash',
+    name: 'Dash App',
+    language: 'python',
+    packages: ['dash', 'plotly', 'pandas', 'numpy'],
+    code: `import dash
+from dash import dcc, html, Input, Output
+import plotly.express as px
+import pandas as pd
+
+df = pd.DataFrame({
+    'Fruit': ['Apples', 'Oranges', 'Bananas', 'Grapes'],
+    'Amount': [4, 1, 2, 3],
+    'City': ['SF', 'SF', 'NYC', 'NYC']
+})
+
+app = dash.Dash(__name__)
+
+app.layout = html.Div([
+    html.H1("My Dash Application", style={'textAlign': 'center'}),
+    html.Div([
+        html.Label("Select City:"),
+        dcc.Dropdown(
+            id='city-dropdown',
+            options=[{'label': city, 'value': city} for city in df['City'].unique()],
+            value='SF'
+        )
+    ], style={'width': '48%', 'display': 'inline-block'}),
+    dcc.Graph(id='fruit-graph'),
+])
+
+@app.callback(
+    Output('fruit-graph', 'figure'),
+    Input('city-dropdown', 'value')
+)
+def update_graph(selected_city):
+    filtered_df = df[df['City'] == selected_city]
+    return px.bar(filtered_df, x='Fruit', y='Amount',
+                  title=f'Fruit Amount in {selected_city}')
+
+if __name__ == '__main__':
+    app.run(host='0.0.0.0', port=8050, debug=True)
+`,
+  },
+
+  // ---------- Node.js ----------
+  {
+    key: 'node-basic',
+    name: 'Basic Node.js',
+    language: 'node',
+    packages: [],
+    code: `// Basic Node.js
+const greet = (name) => \`Hello, \${name}!\`;
+
+console.log(greet("World"));
+console.log("node version:", process.version);
+console.log("NODE_ENV:", process.env.NODE_ENV || "(not set)");
+`,
+  },
+  {
+    key: 'node-fetch',
+    name: 'HTTP + JSON (fetch)',
+    language: 'node',
+    packages: [],
+    code: `// Node 18+ ships a global fetch — no packages needed.
+(async () => {
+  const r = await fetch("https://httpbin.org/json");
+  const data = await r.json();
+  console.log("status:", r.status);
+  console.log("slideshow title:", data.slideshow.title);
+})();
+`,
+  },
+  {
+    key: 'node-lodash',
+    name: 'npm package (lodash)',
+    language: 'node',
+    packages: ['lodash'],
+    code: `const _ = require("lodash");
+
+const people = [
+  { name: "ada", team: "a" },
+  { name: "grace", team: "a" },
+  { name: "linus", team: "b" },
+];
+
+console.log(_.groupBy(people, "team"));
+console.log("lodash version:", _.VERSION);
+`,
+  },
+
+  // ---------- Ruby ----------
+  {
+    key: 'ruby-basic',
+    name: 'Basic Ruby',
+    language: 'ruby',
+    packages: [],
+    code: `# Basic Ruby
+greet = ->(name) { "Hello, #{name}!" }
+puts greet.call("World")
+puts "ruby version: #{RUBY_VERSION}"
+puts "rails? #{defined?(Rails) ? 'yes' : 'no'}"
+`,
+  },
+  {
+    key: 'ruby-json',
+    name: 'JSON manipulation',
+    language: 'ruby',
+    packages: [],
+    code: `require "json"
+
+people = [
+  { name: "ada", team: "a" },
+  { name: "grace", team: "a" },
+  { name: "linus", team: "b" },
+]
+
+by_team = people.group_by { |p| p[:team] }
+puts JSON.pretty_generate(by_team)
+`,
+  },
+  {
+    key: 'ruby-colorize',
+    name: 'gem (colorize)',
+    language: 'ruby',
+    packages: ['colorize'],
+    code: `require "colorize"
+
+puts "green works".colorize(:green)
+puts "red on yellow".colorize(color: :red, background: :yellow)
+`,
+  },
+
+  // ---------- Bash ----------
+  {
+    key: 'bash-basic',
+    name: 'Basic Bash',
+    language: 'bash',
+    packages: [],
+    code: `#!/usr/bin/env bash
+set -euo pipefail
+
+echo "bash version: $BASH_VERSION"
+echo "whoami: $(whoami)"
+echo "uname: $(uname -a)"
+echo "pwd: $(pwd)"
+`,
+  },
+  {
+    key: 'bash-files',
+    name: 'File operations',
+    language: 'bash',
+    packages: [],
+    code: `#!/usr/bin/env bash
+set -euo pipefail
+
+# /tmp is a 128M tmpfs — clean scratch per execution.
+echo "hello" > /tmp/note.txt
+echo "world" >> /tmp/note.txt
+echo "--- files in /tmp ---"
+ls -lah /tmp
+echo "--- contents ---"
+cat /tmp/note.txt
+`,
+  },
+  {
+    key: 'bash-jq',
+    name: 'jq over stdin',
+    language: 'bash',
+    packages: [],
+    code: `#!/usr/bin/env bash
+set -euo pipefail
+
+# curl + jq are preinstalled in the bash runtime.
+cat <<'EOF' | jq '.users | map(.name)'
+{
+  "users": [
+    {"name": "ada",   "team": "a"},
+    {"name": "grace", "team": "a"},
+    {"name": "linus", "team": "b"}
+  ]
+}
+EOF
+`,
+  },
+
+  // ---------- Go ----------
+  {
+    key: 'go-basic',
+    name: 'Basic Go',
+    language: 'go',
+    packages: [],
+    code: `package main
+
+import (
+	"fmt"
+	"runtime"
+)
+
+func main() {
+	fmt.Println("Hello, World!")
+	fmt.Println("go version:", runtime.Version())
+	fmt.Println("numCPU:", runtime.NumCPU())
+}
+`,
+  },
+  {
+    key: 'go-json',
+    name: 'JSON (encoding/json)',
+    language: 'go',
+    packages: [],
+    code: `package main
+
+import (
+	"encoding/json"
+	"fmt"
+)
+
+type Person struct {
+	Name string \`json:"name"\`
+	Team string \`json:"team"\`
+}
+
+func main() {
+	people := []Person{
+		{Name: "ada", Team: "a"},
+		{Name: "grace", Team: "a"},
+		{Name: "linus", Team: "b"},
+	}
+
+	byTeam := map[string][]Person{}
+	for _, p := range people {
+		byTeam[p.Team] = append(byTeam[p.Team], p)
+	}
+
+	out, _ := json.MarshalIndent(byTeam, "", "  ")
+	fmt.Println(string(out))
+}
+`,
+  },
+  {
+    key: 'go-http',
+    name: 'HTTP client (net/http)',
+    language: 'go',
+    packages: [],
+    code: `package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+)
+
+func main() {
+	resp, err := http.Get("https://httpbin.org/json")
+	if err != nil {
+		fmt.Println("error:", err)
+		return
+	}
+	defer resp.Body.Close()
+
+	body, _ := io.ReadAll(resp.Body)
+	var data map[string]any
+	_ = json.Unmarshal(body, &data)
+
+	fmt.Println("status:", resp.Status)
+	if slideshow, ok := data["slideshow"].(map[string]any); ok {
+		fmt.Println("slideshow title:", slideshow["title"])
+	}
+}
+`,
+  },
+];
+
+export const templatesForLanguage = (language: string): AppTemplate[] =>
+  APP_TEMPLATES.filter((t) => t.language === language);
+
+export const defaultTemplateForLanguage = (language: string): AppTemplate | undefined =>
+  APP_TEMPLATES.find((t) => t.language === language);
+
+export const templateByKey = (key: string): AppTemplate | undefined =>
+  APP_TEMPLATES.find((t) => t.key === key);

--- a/frontend/src/pages/AdminUsers.tsx
+++ b/frontend/src/pages/AdminUsers.tsx
@@ -1,0 +1,348 @@
+import React, { useCallback, useEffect, useState } from 'react';
+import {
+  Box,
+  Button,
+  Typography,
+  Paper,
+  TextField,
+  Table,
+  TableHead,
+  TableRow,
+  TableCell,
+  TableBody,
+  IconButton,
+  Dialog,
+  DialogTitle,
+  DialogContent,
+  DialogActions,
+  Alert,
+  Chip,
+  Tooltip,
+  Switch,
+  CircularProgress,
+  FormControlLabel,
+} from '@mui/material';
+import {
+  Delete as DeleteIcon,
+  PersonAdd as PersonAddIcon,
+  VpnKey as ResetPwIcon,
+} from '@mui/icons-material';
+import { api, extractErrorMessage } from '../config/api';
+import { useAuth, AuthUser } from '../auth/AuthContext';
+
+const SYSTEM_USER_ID = 1;
+
+interface NewUserForm {
+  email: string;
+  password: string;
+  is_admin: boolean;
+}
+
+const AdminUsers: React.FC = () => {
+  const { user: me } = useAuth();
+  const [users, setUsers] = useState<AuthUser[] | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [createOpen, setCreateOpen] = useState(false);
+  const [form, setForm] = useState<NewUserForm>({
+    email: '',
+    password: '',
+    is_admin: false,
+  });
+  const [submitting, setSubmitting] = useState(false);
+  const [resetFor, setResetFor] = useState<AuthUser | null>(null);
+  const [resetPwd, setResetPwd] = useState('');
+
+  const load = useCallback(async () => {
+    setError(null);
+    try {
+      const r = await api.get<AuthUser[]>('/admin/users');
+      setUsers(r.data);
+    } catch (e) {
+      setError(extractErrorMessage(e, 'Could not load users'));
+      setUsers([]);
+    }
+  }, []);
+
+  useEffect(() => {
+    load();
+  }, [load]);
+
+  if (!me?.is_admin) {
+    return (
+      <Paper sx={{ p: 3 }}>
+        <Typography variant="h5" sx={{ mb: 1 }}>
+          Admin: users
+        </Typography>
+        <Alert severity="warning">Admin access required.</Alert>
+      </Paper>
+    );
+  }
+
+  const handleCreate = async () => {
+    setSubmitting(true);
+    setError(null);
+    try {
+      await api.post('/admin/users', form);
+      setForm({ email: '', password: '', is_admin: false });
+      setCreateOpen(false);
+      await load();
+    } catch (e) {
+      setError(extractErrorMessage(e, 'Could not create user'));
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  const handleDelete = async (u: AuthUser) => {
+    if (!confirm(`Delete ${u.email}? This revokes their keys and can't be undone.`)) return;
+    setError(null);
+    try {
+      await api.delete(`/admin/users/${u.id}`);
+      await load();
+    } catch (e) {
+      setError(extractErrorMessage(e, 'Could not delete user'));
+    }
+  };
+
+  const toggleDisabled = async (u: AuthUser) => {
+    setError(null);
+    try {
+      await api.patch(`/admin/users/${u.id}`, { disabled: !u.disabled });
+      await load();
+    } catch (e) {
+      setError(extractErrorMessage(e, 'Could not update user'));
+    }
+  };
+
+  const toggleAdmin = async (u: AuthUser) => {
+    setError(null);
+    try {
+      await api.patch(`/admin/users/${u.id}`, { is_admin: !u.is_admin });
+      await load();
+    } catch (e) {
+      setError(extractErrorMessage(e, 'Could not update user'));
+    }
+  };
+
+  const doResetPassword = async () => {
+    if (!resetFor) return;
+    setSubmitting(true);
+    setError(null);
+    try {
+      await api.patch(`/admin/users/${resetFor.id}`, { password: resetPwd });
+      setResetFor(null);
+      setResetPwd('');
+    } catch (e) {
+      setError(extractErrorMessage(e, 'Could not reset password'));
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  return (
+    <Box>
+      <Box sx={{ display: 'flex', alignItems: 'center', mb: 2, gap: 2 }}>
+        <Typography variant="h5" sx={{ flexGrow: 1 }}>
+          Admin: users
+        </Typography>
+        <Button
+          variant="contained"
+          startIcon={<PersonAddIcon />}
+          onClick={() => setCreateOpen(true)}
+        >
+          New user
+        </Button>
+      </Box>
+
+      {error && (
+        <Alert severity="error" sx={{ mb: 2 }}>
+          {error}
+        </Alert>
+      )}
+
+      <Paper>
+        {users === null ? (
+          <Box sx={{ p: 4, display: 'flex', justifyContent: 'center' }}>
+            <CircularProgress size={24} />
+          </Box>
+        ) : (
+          <Table size="small">
+            <TableHead>
+              <TableRow>
+                <TableCell>ID</TableCell>
+                <TableCell>Email</TableCell>
+                <TableCell>Role</TableCell>
+                <TableCell>Enabled</TableCell>
+                <TableCell>Created</TableCell>
+                <TableCell align="right">Actions</TableCell>
+              </TableRow>
+            </TableHead>
+            <TableBody>
+              {users.map((u) => {
+                const isSystem = u.id === SYSTEM_USER_ID;
+                const isSelf = me?.id === u.id;
+                return (
+                  <TableRow key={u.id}>
+                    <TableCell>{u.id}</TableCell>
+                    <TableCell>
+                      {u.email}
+                      {isSelf && (
+                        <Chip
+                          size="small"
+                          label="you"
+                          sx={{ ml: 1 }}
+                          color="primary"
+                        />
+                      )}
+                      {isSystem && (
+                        <Chip
+                          size="small"
+                          label="system"
+                          sx={{ ml: 1 }}
+                          variant="outlined"
+                        />
+                      )}
+                    </TableCell>
+                    <TableCell>
+                      <Tooltip title={isSystem ? 'System user — role is fixed' : 'Toggle admin'}>
+                        <span>
+                          <Switch
+                            size="small"
+                            checked={u.is_admin}
+                            disabled={isSystem || isSelf}
+                            onChange={() => toggleAdmin(u)}
+                          />
+                        </span>
+                      </Tooltip>
+                      {u.is_admin ? 'admin' : 'user'}
+                    </TableCell>
+                    <TableCell>
+                      <Tooltip title={isSystem ? 'System user — always enabled' : 'Toggle enabled'}>
+                        <span>
+                          <Switch
+                            size="small"
+                            checked={!u.disabled}
+                            disabled={isSystem || isSelf}
+                            onChange={() => toggleDisabled(u)}
+                          />
+                        </span>
+                      </Tooltip>
+                    </TableCell>
+                    <TableCell>
+                      {u.created_at
+                        ? new Date(u.created_at).toLocaleDateString()
+                        : ''}
+                    </TableCell>
+                    <TableCell align="right">
+                      {!isSystem && (
+                        <>
+                          <Tooltip title="Reset password">
+                            <IconButton
+                              size="small"
+                              onClick={() => {
+                                setResetFor(u);
+                                setResetPwd('');
+                              }}
+                            >
+                              <ResetPwIcon fontSize="small" />
+                            </IconButton>
+                          </Tooltip>
+                          <Tooltip title={isSelf ? "Can't delete yourself" : 'Delete user'}>
+                            <span>
+                              <IconButton
+                                size="small"
+                                disabled={isSelf}
+                                onClick={() => handleDelete(u)}
+                              >
+                                <DeleteIcon fontSize="small" />
+                              </IconButton>
+                            </span>
+                          </Tooltip>
+                        </>
+                      )}
+                    </TableCell>
+                  </TableRow>
+                );
+              })}
+            </TableBody>
+          </Table>
+        )}
+      </Paper>
+
+      {/* Create dialog */}
+      <Dialog open={createOpen} onClose={() => setCreateOpen(false)}>
+        <DialogTitle>Create user</DialogTitle>
+        <DialogContent>
+          <TextField
+            label="Email"
+            type="email"
+            fullWidth
+            required
+            value={form.email}
+            onChange={(e) => setForm({ ...form, email: e.target.value })}
+            sx={{ mt: 1, minWidth: 380 }}
+            autoFocus
+          />
+          <TextField
+            label="Initial password"
+            type="password"
+            fullWidth
+            required
+            value={form.password}
+            onChange={(e) => setForm({ ...form, password: e.target.value })}
+            sx={{ mt: 2 }}
+          />
+          <FormControlLabel
+            control={
+              <Switch
+                checked={form.is_admin}
+                onChange={(e) => setForm({ ...form, is_admin: e.target.checked })}
+              />
+            }
+            label="Admin"
+            sx={{ mt: 1 }}
+          />
+        </DialogContent>
+        <DialogActions>
+          <Button onClick={() => setCreateOpen(false)}>Cancel</Button>
+          <Button
+            variant="contained"
+            onClick={handleCreate}
+            disabled={submitting || !form.email || !form.password}
+          >
+            {submitting ? <CircularProgress size={18} /> : 'Create'}
+          </Button>
+        </DialogActions>
+      </Dialog>
+
+      {/* Reset password dialog */}
+      <Dialog open={!!resetFor} onClose={() => setResetFor(null)}>
+        <DialogTitle>Reset password — {resetFor?.email}</DialogTitle>
+        <DialogContent>
+          <TextField
+            label="New password"
+            type="password"
+            fullWidth
+            required
+            value={resetPwd}
+            onChange={(e) => setResetPwd(e.target.value)}
+            sx={{ mt: 1, minWidth: 380 }}
+            autoFocus
+          />
+        </DialogContent>
+        <DialogActions>
+          <Button onClick={() => setResetFor(null)}>Cancel</Button>
+          <Button
+            variant="contained"
+            onClick={doResetPassword}
+            disabled={submitting || !resetPwd}
+          >
+            {submitting ? <CircularProgress size={18} /> : 'Reset'}
+          </Button>
+        </DialogActions>
+      </Dialog>
+    </Box>
+  );
+};
+
+export default AdminUsers;

--- a/frontend/src/pages/ApiKeys.tsx
+++ b/frontend/src/pages/ApiKeys.tsx
@@ -1,0 +1,268 @@
+import React, { useCallback, useEffect, useState } from 'react';
+import {
+  Box,
+  Button,
+  Typography,
+  Paper,
+  TextField,
+  Table,
+  TableHead,
+  TableRow,
+  TableCell,
+  TableBody,
+  IconButton,
+  Dialog,
+  DialogTitle,
+  DialogContent,
+  DialogActions,
+  Alert,
+  Tooltip,
+  CircularProgress,
+} from '@mui/material';
+import {
+  ContentCopy as CopyIcon,
+  Delete as DeleteIcon,
+  Add as AddIcon,
+} from '@mui/icons-material';
+import { api, extractErrorMessage } from '../config/api';
+import { useAuth } from '../auth/AuthContext';
+
+interface ApiKey {
+  id: number;
+  prefix: string;
+  label: string | null;
+  last_used_at: string | null;
+  created_at: string;
+}
+
+interface CreatedKey extends ApiKey {
+  token: string; // plaintext, returned exactly once
+}
+
+const ApiKeys: React.FC = () => {
+  const { user } = useAuth();
+  const [keys, setKeys] = useState<ApiKey[] | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [createOpen, setCreateOpen] = useState(false);
+  const [label, setLabel] = useState('');
+  const [creating, setCreating] = useState(false);
+  const [created, setCreated] = useState<CreatedKey | null>(null);
+  const [copied, setCopied] = useState(false);
+
+  const load = useCallback(async () => {
+    setError(null);
+    try {
+      const r = await api.get<ApiKey[]>('/users/me/keys');
+      setKeys(r.data);
+    } catch (e) {
+      setError(extractErrorMessage(e, 'Could not load API keys'));
+      setKeys([]);
+    }
+  }, []);
+
+  useEffect(() => {
+    load();
+  }, [load]);
+
+  const isAnonymous = !user || user.id === 1;
+
+  const handleCreate = async () => {
+    setCreating(true);
+    setError(null);
+    try {
+      const r = await api.post<CreatedKey>('/users/me/keys', { label: label || null });
+      setCreated(r.data);
+      setLabel('');
+      setCreateOpen(false);
+      await load();
+    } catch (e) {
+      setError(extractErrorMessage(e, 'Could not create key'));
+    } finally {
+      setCreating(false);
+    }
+  };
+
+  const handleDelete = async (id: number) => {
+    setError(null);
+    try {
+      await api.delete(`/users/me/keys/${id}`);
+      await load();
+    } catch (e) {
+      setError(extractErrorMessage(e, 'Could not revoke key'));
+    }
+  };
+
+  const copyToken = async () => {
+    if (!created) return;
+    try {
+      await navigator.clipboard.writeText(created.token);
+      setCopied(true);
+      setTimeout(() => setCopied(false), 1500);
+    } catch {
+      /* clipboard may be blocked; user can still select manually */
+    }
+  };
+
+  if (isAnonymous) {
+    return (
+      <Paper sx={{ p: 3 }}>
+        <Typography variant="h5" sx={{ mb: 1 }}>
+          API keys
+        </Typography>
+        <Alert severity="info">
+          Sign in to manage API keys. Anonymous sessions use the shared system
+          identity and can't mint keys.
+        </Alert>
+      </Paper>
+    );
+  }
+
+  return (
+    <Box>
+      <Box sx={{ display: 'flex', alignItems: 'center', mb: 2, gap: 2 }}>
+        <Typography variant="h5" sx={{ flexGrow: 1 }}>
+          API keys
+        </Typography>
+        <Button
+          variant="contained"
+          startIcon={<AddIcon />}
+          onClick={() => setCreateOpen(true)}
+        >
+          New key
+        </Button>
+      </Box>
+
+      <Typography variant="body2" color="text.secondary" sx={{ mb: 2 }}>
+        Long-lived bearer tokens for CLI / CI use. Send as{' '}
+        <code>Authorization: Bearer &lt;key&gt;</code>. The token is shown
+        <strong> exactly once</strong> at creation — store it immediately.
+      </Typography>
+
+      {error && (
+        <Alert severity="error" sx={{ mb: 2 }}>
+          {error}
+        </Alert>
+      )}
+
+      <Paper>
+        {keys === null ? (
+          <Box sx={{ p: 4, display: 'flex', justifyContent: 'center' }}>
+            <CircularProgress size={24} />
+          </Box>
+        ) : keys.length === 0 ? (
+          <Box sx={{ p: 3 }}>
+            <Typography color="text.secondary">
+              No active keys. Click "New key" to mint one.
+            </Typography>
+          </Box>
+        ) : (
+          <Table size="small">
+            <TableHead>
+              <TableRow>
+                <TableCell>Label</TableCell>
+                <TableCell>Prefix</TableCell>
+                <TableCell>Created</TableCell>
+                <TableCell>Last used</TableCell>
+                <TableCell align="right">Actions</TableCell>
+              </TableRow>
+            </TableHead>
+            <TableBody>
+              {keys.map((k) => (
+                <TableRow key={k.id}>
+                  <TableCell>{k.label || <em>—</em>}</TableCell>
+                  <TableCell>
+                    <code>{k.prefix}…</code>
+                  </TableCell>
+                  <TableCell>
+                    {new Date(k.created_at).toLocaleString()}
+                  </TableCell>
+                  <TableCell>
+                    {k.last_used_at
+                      ? new Date(k.last_used_at).toLocaleString()
+                      : <em style={{ color: '#888' }}>never</em>}
+                  </TableCell>
+                  <TableCell align="right">
+                    <Tooltip title="Revoke">
+                      <IconButton
+                        size="small"
+                        onClick={() => handleDelete(k.id)}
+                      >
+                        <DeleteIcon fontSize="small" />
+                      </IconButton>
+                    </Tooltip>
+                  </TableCell>
+                </TableRow>
+              ))}
+            </TableBody>
+          </Table>
+        )}
+      </Paper>
+
+      {/* Create dialog */}
+      <Dialog open={createOpen} onClose={() => setCreateOpen(false)}>
+        <DialogTitle>New API key</DialogTitle>
+        <DialogContent>
+          <TextField
+            label="Label (optional)"
+            fullWidth
+            value={label}
+            onChange={(e) => setLabel(e.target.value)}
+            helperText="Something to remember what this key is for, e.g. ci, laptop."
+            sx={{ mt: 1, minWidth: 380 }}
+            autoFocus
+          />
+        </DialogContent>
+        <DialogActions>
+          <Button onClick={() => setCreateOpen(false)}>Cancel</Button>
+          <Button variant="contained" onClick={handleCreate} disabled={creating}>
+            {creating ? <CircularProgress size={18} /> : 'Create'}
+          </Button>
+        </DialogActions>
+      </Dialog>
+
+      {/* Show-once plaintext dialog */}
+      <Dialog
+        open={!!created}
+        onClose={() => setCreated(null)}
+        maxWidth="sm"
+        fullWidth
+      >
+        <DialogTitle>Copy your new API key</DialogTitle>
+        <DialogContent>
+          <Alert severity="warning" sx={{ mb: 2 }}>
+            This is the only time the full token is shown. Store it somewhere
+            durable now — we only keep its hash on the server.
+          </Alert>
+          <Box
+            sx={{
+              p: 1.5,
+              border: '1px solid',
+              borderColor: 'divider',
+              borderRadius: 1,
+              display: 'flex',
+              alignItems: 'center',
+              gap: 1,
+              fontFamily: 'monospace',
+              fontSize: 13,
+              wordBreak: 'break-all',
+            }}
+          >
+            <Box sx={{ flexGrow: 1 }}>{created?.token}</Box>
+            <Tooltip title={copied ? 'Copied!' : 'Copy'}>
+              <IconButton size="small" onClick={copyToken}>
+                <CopyIcon fontSize="small" />
+              </IconButton>
+            </Tooltip>
+          </Box>
+        </DialogContent>
+        <DialogActions>
+          <Button onClick={() => setCreated(null)} variant="contained">
+            Done
+          </Button>
+        </DialogActions>
+      </Dialog>
+    </Box>
+  );
+};
+
+export default ApiKeys;

--- a/frontend/src/pages/Editor.tsx
+++ b/frontend/src/pages/Editor.tsx
@@ -4,6 +4,12 @@ import { Add as AddIcon, Delete as DeleteIcon, PlayArrow as PlayIcon, Launch as 
 import Editor from '@monaco-editor/react';
 import api, { extractErrorMessage } from '../config/api';
 import { Runtime, fetchRuntimes, monacoLanguageFor } from '../config/languages';
+import {
+  APP_TEMPLATES,
+  templatesForLanguage,
+  defaultTemplateForLanguage,
+  templateByKey,
+} from '../config/templates';
 
 interface CodeSession {
   id: string;
@@ -20,184 +26,15 @@ interface WebService {
   proxy_url: string;
 }
 
-const appTemplates = {
-  basic: {
-    name: 'Basic Python',
-    packages: [],
-    code: `# Write your Python code here
-import os
-
-# Example 1: Get environment variable with default value
-database_url = os.getenv('DATABASE_URL', 'sqlite:///default.db')
-print(f"Database URL: {database_url}")
-
-# Example 2: Get required environment variable (raises error if not found)
-try:
-    api_key = os.environ['API_KEY']
-    print(f"API Key found: {api_key[:8]}...")
-except KeyError:
-    print("API_KEY environment variable not set")
-
-# Example 3: Get environment variable with type conversion
-debug_mode = os.getenv('DEBUG', 'false').lower() == 'true'
-print(f"Debug mode: {debug_mode}")
-
-# Example 4: List all environment variables
-print("\\nAll environment variables:")
-for key, value in os.environ.items():
-    print(f"{key}: {value}")
-
-print("Hello, World!")`
-  },
-  gradio: {
-    name: 'Gradio App',
-    packages: ['gradio'],
-    code: `import gradio as gr
-
-def greet(name):
-    return f"Hello, {name}!"
-
-with gr.Blocks() as demo:
-    inp = gr.Textbox(label="Your name")
-    out = gr.Textbox(label="Greeting")
-    btn = gr.Button("Greet")
-    btn.click(fn=greet, inputs=inp, outputs=out)
-
-if __name__ == "__main__":
-    demo.launch(server_name="0.0.0.0", server_port=7860)
-`
-  },
-  fastapi: {
-    name: 'FastAPI App',
-    packages: ['fastapi', 'uvicorn'],
-    code: `from fastapi import FastAPI
-import uvicorn
-
-app = FastAPI(title="My API", description="A simple FastAPI application")
-
-@app.get("/")
-def read_root():
-    return {"message": "Hello World", "status": "running"}
-
-@app.get("/items/{item_id}")
-def read_item(item_id: int, q: str = None):
-    return {"item_id": item_id, "q": q}
-
-@app.get("/health")
-def health_check():
-    return {"status": "healthy"}
-
-if __name__ == "__main__":
-    # This will start the server
-    uvicorn.run(app, host="0.0.0.0", port=8000)
-`
-  },
-  flask: {
-    name: 'Flask App',
-    packages: ['flask'],
-    code: `from flask import Flask, jsonify, render_template_string
-
-app = Flask(__name__)
-
-# Simple HTML template
-HTML_TEMPLATE = '''
-<!DOCTYPE html>
-<html>
-<head>
-    <title>My Flask App</title>
-    <style>
-        body { font-family: Arial, sans-serif; margin: 40px; }
-        .container { max-width: 600px; margin: 0 auto; }
-        h1 { color: #333; }
-        .btn { background: #007bff; color: white; padding: 10px 20px; 
-               text-decoration: none; border-radius: 5px; }
-    </style>
-</head>
-<body>
-    <div class="container">
-        <h1>Welcome to My Flask App!</h1>
-        <p>This is a simple Flask application.</p>
-        <a href="/api/data" class="btn">View API Data</a>
-    </div>
-</body>
-</html>
-'''
-
-@app.route('/')
-def home():
-    return render_template_string(HTML_TEMPLATE)
-
-@app.route('/api/data')
-def get_data():
-    return jsonify({
-        "message": "Hello from Flask!",
-        "data": [1, 2, 3, 4, 5],
-        "status": "success"
-    })
-
-if __name__ == '__main__':
-    app.run(host='0.0.0.0', port=5000, debug=True)
-`
-  },
-  dash: {
-    name: 'Dash App',
-    packages: ['dash', 'plotly', 'pandas', 'numpy'],
-    code: `import dash
-from dash import dcc, html, Input, Output
-import plotly.express as px
-import pandas as pd
-
-# Create sample data
-df = pd.DataFrame({
-    'Fruit': ['Apples', 'Oranges', 'Bananas', 'Grapes'],
-    'Amount': [4, 1, 2, 3],
-    'City': ['SF', 'SF', 'NYC', 'NYC']
-})
-
-# Initialize the Dash app
-app = dash.Dash(__name__)
-
-# Define the layout
-app.layout = html.Div([
-    html.H1("My Dash Application", style={'textAlign': 'center'}),
-    
-    html.Div([
-        html.Label("Select City:"),
-        dcc.Dropdown(
-            id='city-dropdown',
-            options=[{'label': city, 'value': city} for city in df['City'].unique()],
-            value='SF'
-        )
-    ], style={'width': '48%', 'display': 'inline-block'}),
-    
-    dcc.Graph(id='fruit-graph'),
-    
-    html.Div([
-        html.H3("Sample Text"),
-        html.P("This is a sample Dash application with interactive components!")
-    ])
-])
-
-# Callback for updating the graph
-@app.callback(
-    Output('fruit-graph', 'figure'),
-    Input('city-dropdown', 'value')
-)
-def update_graph(selected_city):
-    filtered_df = df[df['City'] == selected_city]
-    fig = px.bar(filtered_df, x='Fruit', y='Amount', 
-                 title=f'Fruit Amount in {selected_city}')
-    return fig
-
-if __name__ == '__main__':
-    app.run(host='0.0.0.0', port=8050, debug=True)
-`
-  }
-};
+// Templates now live in config/templates.ts (one flat list, per-language).
+// The "Basic Python" template is the conventional blank-slate starting
+// point; kept around as a named constant so the auto-save guard below
+// doesn't flag it as user content.
+const BASIC_PYTHON = APP_TEMPLATES.find((t) => t.key === 'python-basic')!;
 
 const CodeEditor: React.FC = () => {
-  const [selectedTemplate, setSelectedTemplate] = useState('basic');
-  const [code, setCode] = useState(appTemplates.basic.code);
+  const [selectedTemplate, setSelectedTemplate] = useState('python-basic');
+  const [code, setCode] = useState(BASIC_PYTHON.code);
   const [packages, setPackages] = useState<string[]>(['']);
   const [output, setOutput] = useState<string>('');
   const [isScheduled, setIsScheduled] = useState(false);
@@ -235,7 +72,7 @@ const CodeEditor: React.FC = () => {
   // Auto-save current editor state to localStorage
   useEffect(() => {
     // Only auto-save if not currently loading a template or session
-    if (code && code !== appTemplates.basic.code) {
+    if (code && code !== BASIC_PYTHON.code) {
       saveAutoSavedState();
     }
   }, [code, packages]);
@@ -304,16 +141,37 @@ const CodeEditor: React.FC = () => {
   };
 
   const handleTemplateChange = (templateKey: string) => {
-    const template = appTemplates[templateKey as keyof typeof appTemplates];
+    const template = templateByKey(templateKey);
+    if (!template) return;
     setSelectedTemplate(templateKey);
     setCode(template.code);
-    setPackages(template.packages.length > 0 ? template.packages : ['']);
+    setPackages(template.packages.length > 0 ? [...template.packages] : ['']);
+    // A template carries its own language — switching template also
+    // switches the runtime so Monaco's syntax highlighting and the
+    // /execute request body both stay consistent.
+    if (template.language !== language) {
+      setLanguage(template.language);
+    }
     setWebService(null);
     setCurrentSessionId(null);
     setSelectedSession('');
-    // Clear auto-saved state when loading a template
     clearAutoSavedState();
   };
+
+  // When the language changes (either directly or via a template), make
+  // sure the template dropdown points at a template that belongs to the
+  // new language. Otherwise the dropdown shows an out-of-list value and
+  // the displayed label mismatches the selected runtime.
+  useEffect(() => {
+    const current = templateByKey(selectedTemplate);
+    if (current && current.language === language) return;
+    const fallback = defaultTemplateForLanguage(language);
+    setSelectedTemplate(fallback ? fallback.key : '');
+    // Intentionally don't reset `code` here — the user may be typing in
+    // a language we just switched to. Templates are a scaffolding aid,
+    // not a source of truth for the current buffer.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [language]);
 
   const handleSessionLoad = (sessionId: string) => {
     const session = codeSessions.find((s: CodeSession) => s.id === sessionId);
@@ -489,16 +347,22 @@ const CodeEditor: React.FC = () => {
         <TextField
           select
           size="small"
-          label="App Template"
+          label="Template"
           value={selectedTemplate}
           onChange={(e) => handleTemplateChange(e.target.value)}
           sx={{ minWidth: 200 }}
         >
-          {Object.entries(appTemplates).map(([key, template]) => (
-            <MenuItem key={key} value={key}>
-              {template.name}
+          {templatesForLanguage(language).length === 0 ? (
+            <MenuItem value="" disabled>
+              <em>No templates for this runtime</em>
             </MenuItem>
-          ))}
+          ) : (
+            templatesForLanguage(language).map((template) => (
+              <MenuItem key={template.key} value={template.key}>
+                {template.name}
+              </MenuItem>
+            ))
+          )}
         </TextField>
         
         <TextField

--- a/frontend/src/pages/Editor.tsx
+++ b/frontend/src/pages/Editor.tsx
@@ -3,6 +3,7 @@ import { Box, Grid, Paper, Typography, Button, TextField, IconButton, Switch, Fo
 import { Add as AddIcon, Delete as DeleteIcon, PlayArrow as PlayIcon, Launch as LaunchIcon, Save as SaveIcon, Folder as FolderIcon } from '@mui/icons-material';
 import Editor from '@monaco-editor/react';
 import api, { extractErrorMessage } from '../config/api';
+import { Runtime, fetchRuntimes, monacoLanguageFor } from '../config/languages';
 
 interface CodeSession {
   id: string;
@@ -214,11 +215,22 @@ const CodeEditor: React.FC = () => {
   const [sessionName, setSessionName] = useState('');
   const [currentSessionId, setCurrentSessionId] = useState<string | null>(null);
 
+  // Language / runtime selection
+  const [runtimes, setRuntimes] = useState<Runtime[]>([]);
+  const [language, setLanguage] = useState<string>('python');
+
   useEffect(() => {
     loadCodeSessions();
     // Load auto-saved editor state on mount
     loadAutoSavedState();
+    // Load available runtimes from the backend
+    fetchRuntimes()
+      .then((rts) => setRuntimes(rts))
+      .catch((err) => console.error('Error fetching runtimes:', err));
   }, []);
+
+  const currentRuntime = runtimes.find((r) => r.name === language);
+  const supportsPackages = currentRuntime ? currentRuntime.supports_packages : true;
 
   // Auto-save current editor state to localStorage
   useEffect(() => {
@@ -390,8 +402,9 @@ const CodeEditor: React.FC = () => {
           name: scheduleName,
           code,
           cron_expression: cronExpression,
-          packages: packages.filter(p => p.trim() !== ''),
+          packages: supportsPackages ? packages.filter(p => p.trim() !== '') : [],
           timeout: timeout,
+          language,
         });
         const endTime = Date.now();
         const execTime = endTime - startTime;
@@ -401,8 +414,9 @@ const CodeEditor: React.FC = () => {
         // Execute code immediately
         const response = await api.post('/execute', {
           code,
-          packages: packages.filter(p => p.trim() !== ''),
+          packages: supportsPackages ? packages.filter(p => p.trim() !== '') : [],
           timeout: timeout,
+          language,
         });
         const endTime = Date.now();
         const execTime = endTime - startTime;
@@ -453,6 +467,25 @@ const CodeEditor: React.FC = () => {
           {currentSessionId ? 'Update' : 'Save'}
         </Button>
         
+        <TextField
+          select
+          size="small"
+          label="Language"
+          value={language}
+          onChange={(e) => setLanguage(e.target.value)}
+          sx={{ minWidth: 140 }}
+        >
+          {runtimes.length === 0 ? (
+            <MenuItem value="python">Python</MenuItem>
+          ) : (
+            runtimes.map((rt) => (
+              <MenuItem key={rt.name} value={rt.name}>
+                {rt.display_name}
+              </MenuItem>
+            ))
+          )}
+        </TextField>
+
         <TextField
           select
           size="small"
@@ -517,7 +550,7 @@ const CodeEditor: React.FC = () => {
           <Paper sx={{ flex: 1, display: 'flex', flexDirection: 'column' }}>
             <Editor
               height="100%"
-              defaultLanguage="python"
+              language={monacoLanguageFor(language)}
               value={code}
               onChange={(value) => setCode(value || '')}
               theme="vs-dark"
@@ -546,7 +579,7 @@ const CodeEditor: React.FC = () => {
           <Paper sx={{ p: 2 }}>
             <Box sx={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', mb: 2 }}>
               <Typography variant="h6">
-                Packages
+                {supportsPackages ? 'Packages' : 'Settings'}
               </Typography>
               {currentSessionId && (
                 <Typography variant="caption" color="primary">
@@ -554,32 +587,45 @@ const CodeEditor: React.FC = () => {
                 </Typography>
               )}
             </Box>
-            {packages.map((package_, index) => (
-              <Box key={index} sx={{ display: 'flex', mb: 1 }}>
-                <TextField
-                  fullWidth
+            {supportsPackages ? (
+              <>
+                {currentRuntime?.package_manager && (
+                  <Typography variant="caption" color="text.secondary" display="block" sx={{ mb: 1 }}>
+                    Managed with {currentRuntime.package_manager}
+                  </Typography>
+                )}
+                {packages.map((package_, index) => (
+                  <Box key={index} sx={{ display: 'flex', mb: 1 }}>
+                    <TextField
+                      fullWidth
+                      size="small"
+                      value={package_}
+                      onChange={(e) => handlePackageChange(index, e.target.value)}
+                      placeholder="Package name"
+                    />
+                    <IconButton
+                      size="small"
+                      onClick={() => handleRemovePackage(index)}
+                      sx={{ ml: 1 }}
+                    >
+                      <DeleteIcon />
+                    </IconButton>
+                  </Box>
+                ))}
+                <Button
+                  startIcon={<AddIcon />}
+                  onClick={handleAddPackage}
                   size="small"
-                  value={package_}
-                  onChange={(e) => handlePackageChange(index, e.target.value)}
-                  placeholder="Package name"
-                />
-                <IconButton
-                  size="small"
-                  onClick={() => handleRemovePackage(index)}
-                  sx={{ ml: 1 }}
+                  sx={{ mt: 1 }}
                 >
-                  <DeleteIcon />
-                </IconButton>
-              </Box>
-            ))}
-            <Button
-              startIcon={<AddIcon />}
-              onClick={handleAddPackage}
-              size="small"
-              sx={{ mt: 1 }}
-            >
-              Add Package
-            </Button>
+                  Add Package
+                </Button>
+              </>
+            ) : (
+              <Typography variant="body2" color="text.secondary">
+                {currentRuntime?.display_name || language} does not support package installation.
+              </Typography>
+            )}
 
             {/* Timeout Settings */}
             <Box sx={{ mt: 2 }}>

--- a/frontend/src/pages/Login.tsx
+++ b/frontend/src/pages/Login.tsx
@@ -1,0 +1,104 @@
+import React, { useState } from 'react';
+import { useNavigate, useLocation } from 'react-router-dom';
+import {
+  Box,
+  Paper,
+  Typography,
+  TextField,
+  Button,
+  Alert,
+  CircularProgress,
+} from '@mui/material';
+import { useAuth } from '../auth/AuthContext';
+import { extractErrorMessage } from '../config/api';
+
+const Login: React.FC = () => {
+  const navigate = useNavigate();
+  const location = useLocation();
+  const { login } = useAuth();
+  const [email, setEmail] = useState('');
+  const [password, setPassword] = useState('');
+  const [submitting, setSubmitting] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  // After successful login, send the user back to wherever they were
+  // trying to go (captured by the guard when it redirected here).
+  const redirectTo =
+    (location.state as { from?: string } | null)?.from || '/';
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    setSubmitting(true);
+    setError(null);
+    try {
+      await login(email, password);
+      navigate(redirectTo, { replace: true });
+    } catch (err) {
+      setError(extractErrorMessage(err, 'Login failed'));
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  return (
+    <Box
+      sx={{
+        minHeight: '100vh',
+        display: 'flex',
+        alignItems: 'center',
+        justifyContent: 'center',
+        p: 2,
+      }}
+    >
+      <Paper sx={{ p: 4, width: 360, maxWidth: '100%' }} elevation={3}>
+        <Typography variant="h5" sx={{ mb: 1 }}>
+          Sign in
+        </Typography>
+        <Typography variant="body2" color="text.secondary" sx={{ mb: 3 }}>
+          supakiln code execution console
+        </Typography>
+
+        <form onSubmit={handleSubmit}>
+          <TextField
+            label="Email"
+            type="email"
+            fullWidth
+            required
+            value={email}
+            onChange={(e) => setEmail(e.target.value)}
+            autoComplete="email"
+            autoFocus
+            sx={{ mb: 2 }}
+          />
+          <TextField
+            label="Password"
+            type="password"
+            fullWidth
+            required
+            value={password}
+            onChange={(e) => setPassword(e.target.value)}
+            autoComplete="current-password"
+            sx={{ mb: 2 }}
+          />
+
+          {error && (
+            <Alert severity="error" sx={{ mb: 2 }}>
+              {error}
+            </Alert>
+          )}
+
+          <Button
+            type="submit"
+            variant="contained"
+            fullWidth
+            disabled={submitting || !email || !password}
+          >
+            {submitting ? <CircularProgress size={20} /> : 'Sign in'}
+          </Button>
+        </form>
+      </Paper>
+    </Box>
+  );
+};
+
+export default Login;

--- a/frontend/src/pages/Scheduler.tsx
+++ b/frontend/src/pages/Scheduler.tsx
@@ -16,9 +16,12 @@ import {
   DialogContent,
   DialogActions,
   Box,
+  TextField,
+  MenuItem,
 } from '@mui/material';
 import { Delete as DeleteIcon, PlayArrow as PlayIcon, Edit as EditIcon } from '@mui/icons-material';
-import api from '../config/api';
+import api, { extractErrorMessage } from '../config/api';
+import { Runtime, fetchRuntimes } from '../config/languages';
 
 interface ScheduledJob {
   id: number;
@@ -29,12 +32,17 @@ interface ScheduledJob {
   is_active: boolean;
   container_id: string | null;
   packages: string | null;
+  language?: string;
 }
 
 const Scheduler: React.FC = () => {
   const [jobs, setJobs] = useState<ScheduledJob[]>([]);
   const [selectedJob, setSelectedJob] = useState<ScheduledJob | null>(null);
   const [isViewDialogOpen, setIsViewDialogOpen] = useState(false);
+  const [runtimes, setRuntimes] = useState<Runtime[]>([]);
+  const [editLanguage, setEditLanguage] = useState<string>('python');
+  const [editCronExpression, setEditCronExpression] = useState<string>('');
+  const [editError, setEditError] = useState<string>('');
 
   const fetchJobs = async () => {
     try {
@@ -47,6 +55,9 @@ const Scheduler: React.FC = () => {
 
   useEffect(() => {
     fetchJobs();
+    fetchRuntimes()
+      .then((rts) => setRuntimes(rts))
+      .catch((err) => console.error('Error fetching runtimes:', err));
   }, []);
 
   const handleDelete = async (id: number) => {
@@ -64,6 +75,7 @@ const Scheduler: React.FC = () => {
         job_id: job.id,
         packages: job.packages ? job.packages.split(',') : [],
         container_id: job.container_id,
+        language: job.language || 'python',
       });
       fetchJobs(); // Refresh to get updated last_run
     } catch (error) {
@@ -73,12 +85,35 @@ const Scheduler: React.FC = () => {
 
   const handleViewJob = (job: ScheduledJob) => {
     setSelectedJob(job);
+    setEditLanguage(job.language || 'python');
+    setEditCronExpression(job.cron_expression);
+    setEditError('');
     setIsViewDialogOpen(true);
+  };
+
+  const handleSaveJob = async () => {
+    if (!selectedJob) return;
+    try {
+      await api.put(`/jobs/${selectedJob.id}`, {
+        name: selectedJob.name,
+        cron_expression: editCronExpression,
+        code: selectedJob.code,
+        packages: selectedJob.packages ? selectedJob.packages.split(',').filter(p => p.trim() !== '') : [],
+        language: editLanguage,
+      });
+      setIsViewDialogOpen(false);
+      setSelectedJob(null);
+      fetchJobs();
+    } catch (error) {
+      console.error('Error updating job:', error);
+      setEditError(extractErrorMessage(error));
+    }
   };
 
   const handleCloseDialog = () => {
     setIsViewDialogOpen(false);
     setSelectedJob(null);
+    setEditError('');
   };
 
   return (
@@ -93,6 +128,7 @@ const Scheduler: React.FC = () => {
               <TableHead>
                 <TableRow>
                   <TableCell>Name</TableCell>
+                  <TableCell>Language</TableCell>
                   <TableCell>Schedule</TableCell>
                   <TableCell>Last Run</TableCell>
                   <TableCell>Status</TableCell>
@@ -103,6 +139,7 @@ const Scheduler: React.FC = () => {
                 {jobs.map((job) => (
                   <TableRow key={job.id}>
                     <TableCell>{job.name}</TableCell>
+                    <TableCell>{job.language || 'python'}</TableCell>
                     <TableCell>{job.cron_expression}</TableCell>
                     <TableCell>
                       {job.last_run ? new Date(job.last_run).toLocaleString() : 'Never'}
@@ -152,22 +189,48 @@ const Scheduler: React.FC = () => {
           <>
             <DialogTitle>Job Details: {selectedJob.name}</DialogTitle>
             <DialogContent>
-              <Box sx={{ mt: 2 }}>
-                <Typography variant="subtitle1" gutterBottom>
-                  Schedule: {selectedJob.cron_expression}
-                </Typography>
-                <Typography variant="subtitle1" gutterBottom>
+              <Box sx={{ mt: 2, display: 'flex', flexDirection: 'column', gap: 2 }}>
+                {editError && (
+                  <Typography variant="body2" color="error">
+                    {editError}
+                  </Typography>
+                )}
+                <TextField
+                  label="Cron Schedule"
+                  value={editCronExpression}
+                  onChange={(e) => setEditCronExpression(e.target.value)}
+                  size="small"
+                  helperText="Format: minute hour day month weekday"
+                />
+                <TextField
+                  select
+                  label="Language"
+                  value={editLanguage}
+                  onChange={(e) => setEditLanguage(e.target.value)}
+                  size="small"
+                >
+                  {runtimes.length === 0 ? (
+                    <MenuItem value="python">Python</MenuItem>
+                  ) : (
+                    runtimes.map((rt) => (
+                      <MenuItem key={rt.name} value={rt.name}>
+                        {rt.display_name}
+                      </MenuItem>
+                    ))
+                  )}
+                </TextField>
+                <Typography variant="subtitle1">
                   Last Run: {selectedJob.last_run ? new Date(selectedJob.last_run).toLocaleString() : 'Never'}
                 </Typography>
-                <Typography variant="subtitle1" gutterBottom>
+                <Typography variant="subtitle1">
                   Status: {selectedJob.is_active ? 'Active' : 'Inactive'}
                 </Typography>
                 {selectedJob.packages && (
-                  <Typography variant="subtitle1" gutterBottom>
+                  <Typography variant="subtitle1">
                     Packages: {selectedJob.packages}
                   </Typography>
                 )}
-                <Typography variant="h6" gutterBottom sx={{ mt: 2 }}>
+                <Typography variant="h6" sx={{ mt: 1 }}>
                   Code
                 </Typography>
                 <Paper
@@ -185,6 +248,7 @@ const Scheduler: React.FC = () => {
             </DialogContent>
             <DialogActions>
               <Button onClick={handleCloseDialog}>Close</Button>
+              <Button onClick={handleSaveJob} variant="contained">Save</Button>
             </DialogActions>
           </>
         )}

--- a/frontend/src/pages/WebhookJobs.tsx
+++ b/frontend/src/pages/WebhookJobs.tsx
@@ -36,6 +36,7 @@ import {
   Code as CodeIcon,
 } from '@mui/icons-material';
 import api, { extractErrorMessage } from '../config/api';
+import { Runtime, fetchRuntimes } from '../config/languages';
 
 interface WebhookJob {
   id: number;
@@ -49,6 +50,7 @@ interface WebhookJob {
   last_triggered: string | null;
   is_active: boolean;
   created_at: string;
+  language?: string;
 }
 
 interface Container {
@@ -66,6 +68,7 @@ interface WebhookJobForm {
   timeout: number;
   description: string;
   is_active: boolean;
+  language: string;
 }
 
 const WebhookJobs: React.FC = () => {
@@ -78,6 +81,7 @@ const WebhookJobs: React.FC = () => {
   const [error, setError] = useState<string>('');
   const [success, setSuccess] = useState<string>('');
   const [tabValue, setTabValue] = useState(0);
+  const [runtimes, setRuntimes] = useState<Runtime[]>([]);
 
   const [formData, setFormData] = useState<WebhookJobForm>({
     name: '',
@@ -88,6 +92,7 @@ const WebhookJobs: React.FC = () => {
     timeout: 30,
     description: '',
     is_active: true,
+    language: 'python',
   });
 
   const fetchJobs = async () => {
@@ -112,6 +117,9 @@ const WebhookJobs: React.FC = () => {
   useEffect(() => {
     fetchJobs();
     fetchContainers();
+    fetchRuntimes()
+      .then((rts) => setRuntimes(rts))
+      .catch((err) => console.error('Error fetching runtimes:', err));
   }, []);
 
   const handleCreate = () => {
@@ -124,6 +132,7 @@ const WebhookJobs: React.FC = () => {
       timeout: 30,
       description: '',
       is_active: true,
+      language: 'python',
     });
     setIsEditing(false);
     setIsFormDialogOpen(true);
@@ -139,6 +148,7 @@ const WebhookJobs: React.FC = () => {
       timeout: job.timeout,
       description: job.description || '',
       is_active: job.is_active,
+      language: job.language || 'python',
     });
     setSelectedJob(job);
     setIsEditing(true);
@@ -261,6 +271,7 @@ const WebhookJobs: React.FC = () => {
                 <TableRow>
                   <TableCell>Name</TableCell>
                   <TableCell>Endpoint</TableCell>
+                  <TableCell>Language</TableCell>
                   <TableCell>Status</TableCell>
                   <TableCell>Last Triggered</TableCell>
                   <TableCell>Timeout</TableCell>
@@ -291,6 +302,9 @@ const WebhookJobs: React.FC = () => {
                           {getWebhookUrl(job.endpoint)}
                         </Typography>
                       </Box>
+                    </TableCell>
+                    <TableCell>
+                      <Chip label={job.language || 'python'} size="small" variant="outlined" />
                     </TableCell>
                     <TableCell>
                       <Chip
@@ -341,7 +355,7 @@ const WebhookJobs: React.FC = () => {
                 ))}
                 {jobs.length === 0 && (
                   <TableRow>
-                    <TableCell colSpan={6} align="center">
+                    <TableCell colSpan={7} align="center">
                       <Typography color="text.secondary">
                         No webhook jobs found. Create your first webhook!
                       </Typography>
@@ -398,6 +412,24 @@ const WebhookJobs: React.FC = () => {
                   multiline
                   rows={2}
                 />
+                <FormControl fullWidth>
+                  <InputLabel>Language</InputLabel>
+                  <Select
+                    value={formData.language}
+                    label="Language"
+                    onChange={(e) => handleFormChange('language', e.target.value)}
+                  >
+                    {runtimes.length === 0 ? (
+                      <MenuItem value="python">Python</MenuItem>
+                    ) : (
+                      runtimes.map((rt) => (
+                        <MenuItem key={rt.name} value={rt.name}>
+                          {rt.display_name}
+                        </MenuItem>
+                      ))
+                    )}
+                  </Select>
+                </FormControl>
                 <FormControlLabel
                   control={
                     <Switch
@@ -492,6 +524,9 @@ const WebhookJobs: React.FC = () => {
                 </Typography>
                 <Typography variant="subtitle1" gutterBottom>
                   <strong>Status:</strong> {selectedJob.is_active ? 'Active' : 'Inactive'}
+                </Typography>
+                <Typography variant="subtitle1" gutterBottom>
+                  <strong>Language:</strong> {selectedJob.language || 'python'}
                 </Typography>
                 <Typography variant="subtitle1" gutterBottom>
                   <strong>Timeout:</strong> {selectedJob.timeout} seconds

--- a/frontend/src/pages/Workers.tsx
+++ b/frontend/src/pages/Workers.tsx
@@ -1,0 +1,227 @@
+import React, { useState, useEffect } from 'react';
+import {
+  Box,
+  Paper,
+  Typography,
+  Table,
+  TableBody,
+  TableCell,
+  TableContainer,
+  TableHead,
+  TableRow,
+  IconButton,
+  Button,
+  Chip,
+  Alert,
+  CircularProgress,
+  Dialog,
+  DialogTitle,
+  DialogContent,
+  DialogContentText,
+  DialogActions,
+  Tooltip,
+} from '@mui/material';
+import {
+  Refresh as RefreshIcon,
+  Stop as StopIcon,
+  DeleteSweep as DeleteSweepIcon,
+} from '@mui/icons-material';
+import api, { extractErrorMessage } from '../config/api';
+import { formatRelativeTime } from '../config/languages';
+
+interface Worker {
+  container_id: string;
+  container_short_id: string;
+  language: string;
+  package_hash: string;
+  cache_key: string;
+  host: string;
+  port: number;
+  created_at: string;
+  last_used: string;
+}
+
+const Workers: React.FC = () => {
+  const [workers, setWorkers] = useState<Worker[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string>('');
+  const [success, setSuccess] = useState<string>('');
+  const [resetDialogOpen, setResetDialogOpen] = useState(false);
+  const [resetting, setResetting] = useState(false);
+
+  const fetchWorkers = async () => {
+    setLoading(true);
+    setError('');
+    try {
+      const response = await api.get('/workers');
+      setWorkers(response.data.workers || []);
+    } catch (err) {
+      console.error('Error fetching workers:', err);
+      setError(extractErrorMessage(err, 'Failed to fetch workers'));
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  useEffect(() => {
+    fetchWorkers();
+  }, []);
+
+  const handleStop = async (worker: Worker) => {
+    try {
+      await api.delete(`/workers/${worker.container_id}`);
+      setSuccess(`Stopped worker ${worker.container_short_id}`);
+      fetchWorkers();
+    } catch (err) {
+      console.error('Error stopping worker:', err);
+      setError(extractErrorMessage(err, 'Failed to stop worker'));
+    }
+  };
+
+  const handleResetAll = async () => {
+    setResetting(true);
+    try {
+      const response = await api.post('/workers/reset');
+      setSuccess(`Reset complete: ${response.data.killed ?? 0} worker(s) stopped`);
+      setResetDialogOpen(false);
+      fetchWorkers();
+    } catch (err) {
+      console.error('Error resetting workers:', err);
+      setError(extractErrorMessage(err, 'Failed to reset workers'));
+    } finally {
+      setResetting(false);
+    }
+  };
+
+  return (
+    <Box>
+      <Box sx={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', mb: 3 }}>
+        <Typography variant="h4">Workers</Typography>
+        <Box sx={{ display: 'flex', gap: 1 }}>
+          <Button
+            variant="outlined"
+            startIcon={<RefreshIcon />}
+            onClick={fetchWorkers}
+            disabled={loading}
+          >
+            Refresh
+          </Button>
+          <Button
+            variant="outlined"
+            color="error"
+            startIcon={<DeleteSweepIcon />}
+            onClick={() => setResetDialogOpen(true)}
+            disabled={workers.length === 0}
+          >
+            Reset All
+          </Button>
+        </Box>
+      </Box>
+
+      {error && (
+        <Alert severity="error" sx={{ mb: 2 }} onClose={() => setError('')}>
+          {error}
+        </Alert>
+      )}
+      {success && (
+        <Alert severity="success" sx={{ mb: 2 }} onClose={() => setSuccess('')}>
+          {success}
+        </Alert>
+      )}
+
+      <Paper sx={{ p: 2 }}>
+        {loading && workers.length === 0 ? (
+          <Box sx={{ display: 'flex', justifyContent: 'center', p: 4 }}>
+            <CircularProgress />
+          </Box>
+        ) : (
+          <TableContainer>
+            <Table>
+              <TableHead>
+                <TableRow>
+                  <TableCell>Short ID</TableCell>
+                  <TableCell>Language</TableCell>
+                  <TableCell>Package Hash</TableCell>
+                  <TableCell>Created</TableCell>
+                  <TableCell>Last Used</TableCell>
+                  <TableCell align="right">Actions</TableCell>
+                </TableRow>
+              </TableHead>
+              <TableBody>
+                {workers.map((worker) => (
+                  <TableRow key={worker.container_id}>
+                    <TableCell>
+                      <Typography variant="body2" fontFamily="monospace">
+                        {worker.container_short_id}
+                      </Typography>
+                    </TableCell>
+                    <TableCell>
+                      <Chip label={worker.language} size="small" variant="outlined" />
+                    </TableCell>
+                    <TableCell>
+                      <Tooltip title={worker.package_hash || ''}>
+                        <Typography variant="body2" fontFamily="monospace">
+                          {worker.package_hash ? worker.package_hash.slice(0, 12) : '-'}
+                        </Typography>
+                      </Tooltip>
+                    </TableCell>
+                    <TableCell>
+                      <Tooltip title={worker.created_at}>
+                        <span>{formatRelativeTime(worker.created_at)}</span>
+                      </Tooltip>
+                    </TableCell>
+                    <TableCell>
+                      <Tooltip title={worker.last_used}>
+                        <span>{formatRelativeTime(worker.last_used)}</span>
+                      </Tooltip>
+                    </TableCell>
+                    <TableCell align="right">
+                      <Tooltip title="Stop worker">
+                        <IconButton
+                          size="small"
+                          color="error"
+                          onClick={() => handleStop(worker)}
+                        >
+                          <StopIcon />
+                        </IconButton>
+                      </Tooltip>
+                    </TableCell>
+                  </TableRow>
+                ))}
+                {workers.length === 0 && !loading && (
+                  <TableRow>
+                    <TableCell colSpan={6} align="center">
+                      <Typography color="text.secondary">
+                        No workers currently running.
+                      </Typography>
+                    </TableCell>
+                  </TableRow>
+                )}
+              </TableBody>
+            </Table>
+          </TableContainer>
+        )}
+      </Paper>
+
+      <Dialog open={resetDialogOpen} onClose={() => !resetting && setResetDialogOpen(false)}>
+        <DialogTitle>Reset all workers?</DialogTitle>
+        <DialogContent>
+          <DialogContentText>
+            This will stop all {workers.length} cached worker container(s). New workers will be
+            started on demand. This action cannot be undone.
+          </DialogContentText>
+        </DialogContent>
+        <DialogActions>
+          <Button onClick={() => setResetDialogOpen(false)} disabled={resetting}>
+            Cancel
+          </Button>
+          <Button onClick={handleResetAll} color="error" variant="contained" disabled={resetting}>
+            {resetting ? 'Resetting...' : 'Reset All'}
+          </Button>
+        </DialogActions>
+      </Dialog>
+    </Box>
+  );
+};
+
+export default Workers;

--- a/languages/__init__.py
+++ b/languages/__init__.py
@@ -1,0 +1,42 @@
+"""Language runtimes for supakiln code execution.
+
+Each runtime describes how to build a per-language container image (base
+image tag, Dockerfile path, package-install snippet) and what port the
+in-container worker listens on. The runtime is the single source of truth
+for "what does language X need"; CodeExecutor stays language-agnostic.
+
+Adding a language means: drop a new Runtime instance into its own module
+(e.g. languages/node.py) and import it from here so registration happens
+at import time.
+"""
+
+from __future__ import annotations
+
+from typing import Dict, List
+
+from .base import Runtime
+from .python import PYTHON
+
+
+_REGISTRY: Dict[str, Runtime] = {}
+
+
+def register(runtime: Runtime) -> None:
+    _REGISTRY[runtime.name] = runtime
+
+
+def get(name: str) -> Runtime:
+    if name not in _REGISTRY:
+        raise KeyError(f"unknown language: {name!r} (known: {sorted(_REGISTRY)})")
+    return _REGISTRY[name]
+
+
+def names() -> List[str]:
+    return sorted(_REGISTRY)
+
+
+# Register built-ins at import time.
+register(PYTHON)
+
+
+__all__ = ["Runtime", "register", "get", "names", "PYTHON"]

--- a/languages/__init__.py
+++ b/languages/__init__.py
@@ -16,6 +16,10 @@ from typing import Dict, List
 
 from .base import Runtime
 from .python import PYTHON
+from .node import NODE
+from .ruby import RUBY
+from .bash import BASH
+from .go import GO
 
 
 _REGISTRY: Dict[str, Runtime] = {}
@@ -36,7 +40,8 @@ def names() -> List[str]:
 
 
 # Register built-ins at import time.
-register(PYTHON)
+for _rt in (PYTHON, NODE, RUBY, BASH, GO):
+    register(_rt)
 
 
-__all__ = ["Runtime", "register", "get", "names", "PYTHON"]
+__all__ = ["Runtime", "register", "get", "names", "PYTHON", "NODE", "RUBY", "BASH", "GO"]

--- a/languages/base.py
+++ b/languages/base.py
@@ -24,9 +24,16 @@ class Runtime:
     #   of packages. `{packages}` is substituted with the shell-quoted
     #   package list. None means this runtime does not support ad-hoc
     #   packages (e.g. bash).
+    file_extension: str = ""          # ".py", ".js", ".sh", ...
+    display_name: str = ""            # "Python", "Node.js", ... (defaults to name.title())
+    package_manager: Optional[str] = None  # "pip", "npm", "gem", None
     worker_port: int = 9999
     # The worker's HTTP contract is identical across languages; only the
     # implementation (the binary invoked by the Dockerfile's CMD) differs.
+
+    @property
+    def supports_packages(self) -> bool:
+        return self.package_install_cmd_template is not None
 
 
 def build_package_install_snippet(runtime: Runtime, packages: List[str]) -> str:

--- a/languages/base.py
+++ b/languages/base.py
@@ -1,0 +1,43 @@
+"""Runtime interface shared by all supported languages."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import List, Optional
+
+
+@dataclass(frozen=True)
+class Runtime:
+    """Describes how to build and run a language-specific worker container.
+
+    The Runtime is intentionally data-only — the build and run logic lives
+    in CodeExecutor, which treats all runtimes uniformly. To add behaviour
+    that differs per-language (e.g. compiled languages needing a build
+    step), extend the Runtime with the extra fields the executor consumes.
+    """
+
+    name: str                         # "python", "node", ...
+    base_image_tag: str               # e.g. "supakiln-python:base"
+    dockerfile_path: str              # "dockerfiles/python.Dockerfile"
+    package_install_cmd_template: Optional[str]
+    # ^ Shell command template run inside the image build to install a list
+    #   of packages. `{packages}` is substituted with the shell-quoted
+    #   package list. None means this runtime does not support ad-hoc
+    #   packages (e.g. bash).
+    worker_port: int = 9999
+    # The worker's HTTP contract is identical across languages; only the
+    # implementation (the binary invoked by the Dockerfile's CMD) differs.
+
+
+def build_package_install_snippet(runtime: Runtime, packages: List[str]) -> str:
+    """Render a Dockerfile RUN line to install `packages`, or empty string.
+
+    Returns "" if no packages or the runtime doesn't support install.
+    Uses shell-safe double-quoting since package specifiers can contain
+    version markers (e.g. `numpy>=1.26`).
+    """
+    if not packages or not runtime.package_install_cmd_template:
+        return ""
+    quoted = " ".join(f'"{pkg}"' for pkg in packages)
+    cmd = runtime.package_install_cmd_template.format(packages=quoted)
+    return f"USER root\nRUN {cmd}\nUSER codeuser\n"

--- a/languages/bash.py
+++ b/languages/bash.py
@@ -9,5 +9,8 @@ BASH = Runtime(
     base_image_tag="supakiln-bash:base",
     dockerfile_path="dockerfiles/bash.Dockerfile",
     package_install_cmd_template=None,
+    file_extension=".sh",
+    display_name="Bash",
+    package_manager=None,
     worker_port=9999,
 )

--- a/languages/bash.py
+++ b/languages/bash.py
@@ -1,0 +1,13 @@
+from __future__ import annotations
+
+from .base import Runtime
+
+
+# Bash scripts call external tools; we don't try to be a package manager.
+BASH = Runtime(
+    name="bash",
+    base_image_tag="supakiln-bash:base",
+    dockerfile_path="dockerfiles/bash.Dockerfile",
+    package_install_cmd_template=None,
+    worker_port=9999,
+)

--- a/languages/go.py
+++ b/languages/go.py
@@ -12,5 +12,8 @@ GO = Runtime(
     base_image_tag="supakiln-go:base",
     dockerfile_path="dockerfiles/go.Dockerfile",
     package_install_cmd_template=None,
+    file_extension=".go",
+    display_name="Go",
+    package_manager=None,
     worker_port=9999,
 )

--- a/languages/go.py
+++ b/languages/go.py
@@ -1,0 +1,16 @@
+from __future__ import annotations
+
+from .base import Runtime
+
+
+# Go dependency management is per-module (go.mod). Ad-hoc `go run` without
+# a module doesn't mesh with `npm install`-style package layering. v1
+# supports stdlib-only Go; dependencies are a follow-up (likely via a
+# synthesized go.mod).
+GO = Runtime(
+    name="go",
+    base_image_tag="supakiln-go:base",
+    dockerfile_path="dockerfiles/go.Dockerfile",
+    package_install_cmd_template=None,
+    worker_port=9999,
+)

--- a/languages/node.py
+++ b/languages/node.py
@@ -1,0 +1,14 @@
+from __future__ import annotations
+
+from .base import Runtime
+
+
+NODE = Runtime(
+    name="node",
+    base_image_tag="supakiln-node:base",
+    dockerfile_path="dockerfiles/node.Dockerfile",
+    # Install into a fixed prefix; the base image sets NODE_PATH so user
+    # code's require() resolves to these modules.
+    package_install_cmd_template="cd /opt/supakiln/pkgs && npm install --no-audit --no-fund {packages}",
+    worker_port=9999,
+)

--- a/languages/node.py
+++ b/languages/node.py
@@ -10,5 +10,8 @@ NODE = Runtime(
     # Install into a fixed prefix; the base image sets NODE_PATH so user
     # code's require() resolves to these modules.
     package_install_cmd_template="cd /opt/supakiln/pkgs && npm install --no-audit --no-fund {packages}",
+    file_extension=".js",
+    display_name="Node.js",
+    package_manager="npm",
     worker_port=9999,
 )

--- a/languages/python.py
+++ b/languages/python.py
@@ -8,5 +8,8 @@ PYTHON = Runtime(
     base_image_tag="supakiln-python:base",
     dockerfile_path="dockerfiles/python.Dockerfile",
     package_install_cmd_template="pip install --no-cache-dir {packages}",
+    file_extension=".py",
+    display_name="Python",
+    package_manager="pip",
     worker_port=9999,
 )

--- a/languages/python.py
+++ b/languages/python.py
@@ -1,0 +1,12 @@
+from __future__ import annotations
+
+from .base import Runtime
+
+
+PYTHON = Runtime(
+    name="python",
+    base_image_tag="supakiln-python:base",
+    dockerfile_path="dockerfiles/python.Dockerfile",
+    package_install_cmd_template="pip install --no-cache-dir {packages}",
+    worker_port=9999,
+)

--- a/languages/ruby.py
+++ b/languages/ruby.py
@@ -1,0 +1,14 @@
+from __future__ import annotations
+
+from .base import Runtime
+
+
+RUBY = Runtime(
+    name="ruby",
+    base_image_tag="supakiln-ruby:base",
+    dockerfile_path="dockerfiles/ruby.Dockerfile",
+    # System-wide gem install; user code `require "gem"` resolves via
+    # Ruby's default load paths.
+    package_install_cmd_template="gem install --no-document {packages}",
+    worker_port=9999,
+)

--- a/languages/ruby.py
+++ b/languages/ruby.py
@@ -10,5 +10,8 @@ RUBY = Runtime(
     # System-wide gem install; user code `require "gem"` resolves via
     # Ruby's default load paths.
     package_install_cmd_template="gem install --no-document {packages}",
+    file_extension=".rb",
+    display_name="Ruby",
+    package_manager="gem",
     worker_port=9999,
 )

--- a/migrate_database.py
+++ b/migrate_database.py
@@ -22,26 +22,26 @@ def migrate_database():
             # No tables exist (or no schema_info), create complete database schema
             print("🆕 Creating complete database schema...")
             create_complete_schema(cursor)
-            current_version = 8
+            current_version = 10
             print(f"✅ Database created with version {current_version}")
         else:
             # Tables exist, check version and apply migrations
             print("🔍 Existing database found, checking version...")
-            
+
             try:
                 cursor.execute("SELECT value FROM schema_info WHERE key = 'version'")
                 current_version = cursor.fetchone()
                 current_version = int(current_version[0]) if current_version else 0
             except sqlite3.OperationalError:
                 current_version = 0
-                
+
             print(f"Current database version: {current_version}")
-            
+
             # Apply migrations if needed
-            if current_version < 8:
-                print(f"⬆️  Upgrading database from version {current_version} to 8...")
+            if current_version < 10:
+                print(f"⬆️  Upgrading database from version {current_version} to 10...")
                 apply_migrations(cursor, current_version)
-                current_version = 8
+                current_version = 10
                 print(f"✅ Database upgraded to version {current_version}")
         
         # Verify the final schema
@@ -59,7 +59,7 @@ def migrate_database():
 
 def create_complete_schema(cursor):
     """Create all tables with the current complete schema."""
-    
+
     # Create schema_info table
     cursor.execute("""
         CREATE TABLE schema_info (
@@ -68,19 +68,63 @@ def create_complete_schema(cursor):
             updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
         )
     """)
-    
-    # Create environment_variables table
+
+    # Create users table. The `system` pseudo-user (id=1) owns every row
+    # that predates auth, and any row created while anonymous access is
+    # enabled. It has no password_hash so nobody can log in as it.
+    cursor.execute("""
+        CREATE TABLE users (
+            id INTEGER PRIMARY KEY,
+            email VARCHAR(255) UNIQUE NOT NULL,
+            password_hash TEXT,
+            is_admin INTEGER NOT NULL DEFAULT 0,
+            disabled INTEGER NOT NULL DEFAULT 0,
+            created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+        )
+    """)
+    cursor.execute(
+        "INSERT INTO users (id, email, password_hash, is_admin) "
+        "VALUES (1, 'system@supakiln.local', NULL, 0)"
+    )
+
+    # Create api_keys table (kind = 'api' for user-managed tokens,
+    # 'session' for login-issued cookies).
+    cursor.execute("""
+        CREATE TABLE api_keys (
+            id INTEGER PRIMARY KEY,
+            user_id INTEGER NOT NULL REFERENCES users(id),
+            hashed_key VARCHAR(64) UNIQUE NOT NULL,
+            prefix VARCHAR(32) NOT NULL,
+            label VARCHAR(100),
+            kind VARCHAR(20) NOT NULL DEFAULT 'api',
+            expires_at TIMESTAMP,
+            last_used_at TIMESTAMP,
+            revoked_at TIMESTAMP,
+            created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+        )
+    """)
+    cursor.execute(
+        "CREATE INDEX idx_api_keys_hashed_key ON api_keys(hashed_key)"
+    )
+    cursor.execute(
+        "CREATE INDEX idx_api_keys_user_id ON api_keys(user_id)"
+    )
+
+    # Create environment_variables table. UNIQUE is composite so two
+    # different users can have the same variable name (e.g. SECRET_KEY).
     cursor.execute("""
         CREATE TABLE environment_variables (
             id INTEGER PRIMARY KEY,
-            name VARCHAR(100) UNIQUE NOT NULL,
+            name VARCHAR(100) NOT NULL,
             value TEXT NOT NULL,
             description TEXT,
+            owner_user_id INTEGER REFERENCES users(id) DEFAULT 1,
             created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
-            updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+            updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+            UNIQUE(owner_user_id, name)
         )
     """)
-    
+
     # Create scheduled_jobs table with timeout column
     cursor.execute("""
         CREATE TABLE scheduled_jobs (
@@ -90,6 +134,7 @@ def create_complete_schema(cursor):
             cron_expression VARCHAR(100) NOT NULL,
             container_id VARCHAR(100),
             packages TEXT,
+            owner_user_id INTEGER REFERENCES users(id),
             created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
             last_run TIMESTAMP,
             is_active INTEGER DEFAULT 1,
@@ -97,7 +142,7 @@ def create_complete_schema(cursor):
             language VARCHAR(20) DEFAULT 'python'
         )
     """)
-    
+
     # Create webhook_jobs table with timeout column
     cursor.execute("""
         CREATE TABLE webhook_jobs (
@@ -107,6 +152,7 @@ def create_complete_schema(cursor):
             code TEXT NOT NULL,
             container_id VARCHAR(100),
             packages TEXT,
+            owner_user_id INTEGER REFERENCES users(id),
             created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
             last_triggered TIMESTAMP,
             is_active INTEGER DEFAULT 1,
@@ -124,6 +170,7 @@ def create_complete_schema(cursor):
             code TEXT NOT NULL,
             container_id VARCHAR(100),
             packages TEXT,
+            owner_user_id INTEGER REFERENCES users(id),
             created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
             started_at TIMESTAMP,
             last_restart TIMESTAMP,
@@ -136,7 +183,7 @@ def create_complete_schema(cursor):
             language VARCHAR(20) DEFAULT 'python'
         )
     """)
-    
+
     # Create exposed_ports table
     cursor.execute("""
         CREATE TABLE exposed_ports (
@@ -153,7 +200,7 @@ def create_complete_schema(cursor):
             description TEXT
         )
     """)
-    
+
     # Create execution_logs table with all columns
     cursor.execute("""
         CREATE TABLE execution_logs (
@@ -161,6 +208,7 @@ def create_complete_schema(cursor):
             job_id INTEGER,
             webhook_job_id INTEGER,
             service_id INTEGER,
+            owner_user_id INTEGER REFERENCES users(id) DEFAULT 1,
             code TEXT NOT NULL,
             output TEXT,
             error TEXT,
@@ -172,9 +220,9 @@ def create_complete_schema(cursor):
             response_data TEXT
         )
     """)
-    
+
     # Set version to latest
-    cursor.execute("INSERT INTO schema_info (key, value) VALUES ('version', '8')")
+    cursor.execute("INSERT INTO schema_info (key, value) VALUES ('version', '10')")
 
 def apply_migrations(cursor, current_version):
     """Apply migrations from current_version to latest."""
@@ -309,8 +357,147 @@ def apply_migrations(cursor, current_version):
                     raise
                 print(f"✅ language column already exists in {table}")
 
+    # Migration v8 -> v9: introduce users + api_keys, and attribute
+    # existing rows to the `system` user (id=1).
+    if current_version < 9:
+        print("Creating users table...")
+        cursor.execute("""
+            CREATE TABLE IF NOT EXISTS users (
+                id INTEGER PRIMARY KEY,
+                email VARCHAR(255) UNIQUE NOT NULL,
+                password_hash TEXT,
+                is_admin INTEGER NOT NULL DEFAULT 0,
+                disabled INTEGER NOT NULL DEFAULT 0,
+                created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+            )
+        """)
+        # Reserve id=1 for the system user if the table is empty.
+        cursor.execute("SELECT COUNT(*) FROM users")
+        if cursor.fetchone()[0] == 0:
+            cursor.execute(
+                "INSERT INTO users (id, email, password_hash, is_admin) "
+                "VALUES (1, 'system@supakiln.local', NULL, 0)"
+            )
+            print("✅ Seeded system user (id=1)")
+
+        print("Creating api_keys table...")
+        cursor.execute("""
+            CREATE TABLE IF NOT EXISTS api_keys (
+                id INTEGER PRIMARY KEY,
+                user_id INTEGER NOT NULL REFERENCES users(id),
+                hashed_key VARCHAR(64) UNIQUE NOT NULL,
+                prefix VARCHAR(32) NOT NULL,
+                label VARCHAR(100),
+                kind VARCHAR(20) NOT NULL DEFAULT 'api',
+                expires_at TIMESTAMP,
+                last_used_at TIMESTAMP,
+                revoked_at TIMESTAMP,
+                created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+            )
+        """)
+        cursor.execute(
+            "CREATE INDEX IF NOT EXISTS idx_api_keys_hashed_key "
+            "ON api_keys(hashed_key)"
+        )
+        cursor.execute(
+            "CREATE INDEX IF NOT EXISTS idx_api_keys_user_id "
+            "ON api_keys(user_id)"
+        )
+
+        # Add owner_user_id to every user-owned table. Default 1 so
+        # existing rows are attributed to the system user — SQLite
+        # does not support setting a DEFAULT via ALTER TABLE with a
+        # non-constant, but CURRENT_TIMESTAMP-style constants are fine
+        # and so is a literal integer. Backfill explicitly regardless.
+        for table in (
+            "environment_variables",
+            "scheduled_jobs",
+            "webhook_jobs",
+            "persistent_services",
+        ):
+            print(f"Adding owner_user_id column to {table}...")
+            try:
+                cursor.execute(
+                    f"ALTER TABLE {table} ADD COLUMN owner_user_id INTEGER "
+                    f"REFERENCES users(id) DEFAULT 1"
+                )
+                print(f"✅ Added owner_user_id column to {table}")
+            except sqlite3.OperationalError as e:
+                if "duplicate column name" not in str(e).lower():
+                    raise
+                print(f"✅ owner_user_id already exists in {table}")
+            cursor.execute(
+                f"UPDATE {table} SET owner_user_id = 1 "
+                f"WHERE owner_user_id IS NULL"
+            )
+
+    # Migration v9 -> v10: attribute log rows to owner, move env-var
+    # uniqueness from global-on-name to per-user-on-name.
+    if current_version < 10:
+        print("Adding owner_user_id column to execution_logs...")
+        try:
+            cursor.execute(
+                "ALTER TABLE execution_logs ADD COLUMN owner_user_id INTEGER "
+                "REFERENCES users(id) DEFAULT 1"
+            )
+            print("✅ Added owner_user_id column to execution_logs")
+        except sqlite3.OperationalError as e:
+            if "duplicate column name" not in str(e).lower():
+                raise
+            print("✅ owner_user_id already exists in execution_logs")
+        cursor.execute(
+            "UPDATE execution_logs SET owner_user_id = 1 "
+            "WHERE owner_user_id IS NULL"
+        )
+
+        # SQLite can't DROP a UNIQUE constraint in-place. Rebuild the
+        # table: rename the old one, recreate with composite unique,
+        # copy rows over, drop the old. Safe because nobody's writing
+        # to this table during startup migration.
+        print("Rebuilding environment_variables with composite unique...")
+        cursor.execute(
+            "SELECT sql FROM sqlite_master WHERE type='table' "
+            "AND name='environment_variables'"
+        )
+        row = cursor.fetchone()
+        current_sql = row[0] if row else ""
+        # Only rebuild if the old-style global UNIQUE on name is still
+        # present (or if the new composite unique is absent). Looking
+        # for "UNIQUE(owner_user_id" avoids rebuilding twice.
+        needs_rebuild = "UNIQUE(owner_user_id" not in (current_sql or "")
+        if needs_rebuild:
+            cursor.execute(
+                "ALTER TABLE environment_variables RENAME TO "
+                "environment_variables_old_v9"
+            )
+            cursor.execute("""
+                CREATE TABLE environment_variables (
+                    id INTEGER PRIMARY KEY,
+                    name VARCHAR(100) NOT NULL,
+                    value TEXT NOT NULL,
+                    description TEXT,
+                    owner_user_id INTEGER REFERENCES users(id) DEFAULT 1,
+                    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+                    updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+                    UNIQUE(owner_user_id, name)
+                )
+            """)
+            cursor.execute("""
+                INSERT INTO environment_variables
+                    (id, name, value, description, owner_user_id,
+                     created_at, updated_at)
+                SELECT id, name, value, description,
+                       COALESCE(owner_user_id, 1),
+                       created_at, updated_at
+                FROM environment_variables_old_v9
+            """)
+            cursor.execute("DROP TABLE environment_variables_old_v9")
+            print("✅ Rebuilt environment_variables with UNIQUE(owner_user_id, name)")
+        else:
+            print("✅ environment_variables already has composite unique")
+
     # Update version
-    cursor.execute("INSERT OR REPLACE INTO schema_info (key, value) VALUES ('version', '8')")
+    cursor.execute("INSERT OR REPLACE INTO schema_info (key, value) VALUES ('version', '10')")
 
 def verify_schema(cursor):
     """Verify that all required tables and columns exist."""
@@ -334,8 +521,9 @@ def verify_schema(cursor):
     existing_tables = [row[0] for row in cursor.fetchall()]
     
     required_tables = [
-        'schema_info', 'environment_variables', 'scheduled_jobs', 
-        'webhook_jobs', 'persistent_services', 'exposed_ports', 'execution_logs'
+        'schema_info', 'environment_variables', 'scheduled_jobs',
+        'webhook_jobs', 'persistent_services', 'exposed_ports',
+        'execution_logs', 'users', 'api_keys'
     ]
     
     for table in required_tables:

--- a/migrate_database.py
+++ b/migrate_database.py
@@ -22,7 +22,7 @@ def migrate_database():
             # No tables exist (or no schema_info), create complete database schema
             print("🆕 Creating complete database schema...")
             create_complete_schema(cursor)
-            current_version = 7
+            current_version = 8
             print(f"✅ Database created with version {current_version}")
         else:
             # Tables exist, check version and apply migrations
@@ -38,10 +38,10 @@ def migrate_database():
             print(f"Current database version: {current_version}")
             
             # Apply migrations if needed
-            if current_version < 7:
-                print(f"⬆️  Upgrading database from version {current_version} to 7...")
+            if current_version < 8:
+                print(f"⬆️  Upgrading database from version {current_version} to 8...")
                 apply_migrations(cursor, current_version)
-                current_version = 7
+                current_version = 8
                 print(f"✅ Database upgraded to version {current_version}")
         
         # Verify the final schema
@@ -93,7 +93,8 @@ def create_complete_schema(cursor):
             created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
             last_run TIMESTAMP,
             is_active INTEGER DEFAULT 1,
-            timeout INTEGER DEFAULT 30
+            timeout INTEGER DEFAULT 30,
+            language VARCHAR(20) DEFAULT 'python'
         )
     """)
     
@@ -110,10 +111,11 @@ def create_complete_schema(cursor):
             last_triggered TIMESTAMP,
             is_active INTEGER DEFAULT 1,
             timeout INTEGER DEFAULT 30,
-            description TEXT
+            description TEXT,
+            language VARCHAR(20) DEFAULT 'python'
         )
     """)
-    
+
     # Create persistent_services table
     cursor.execute("""
         CREATE TABLE persistent_services (
@@ -130,7 +132,8 @@ def create_complete_schema(cursor):
             restart_policy VARCHAR(20) DEFAULT 'always',
             description TEXT,
             process_id VARCHAR(100),
-            auto_start INTEGER DEFAULT 1
+            auto_start INTEGER DEFAULT 1,
+            language VARCHAR(20) DEFAULT 'python'
         )
     """)
     
@@ -171,7 +174,7 @@ def create_complete_schema(cursor):
     """)
     
     # Set version to latest
-    cursor.execute("INSERT INTO schema_info (key, value) VALUES ('version', '7')")
+    cursor.execute("INSERT INTO schema_info (key, value) VALUES ('version', '8')")
 
 def apply_migrations(cursor, current_version):
     """Apply migrations from current_version to latest."""
@@ -292,8 +295,22 @@ def apply_migrations(cursor, current_version):
         )
     """)
     
+    # Migration v7 -> v8: add `language` column to code-bearing tables
+    if current_version < 8:
+        for table in ("scheduled_jobs", "webhook_jobs", "persistent_services"):
+            print(f"Adding language column to {table}...")
+            try:
+                cursor.execute(
+                    f"ALTER TABLE {table} ADD COLUMN language VARCHAR(20) DEFAULT 'python'"
+                )
+                print(f"✅ Added language column to {table}")
+            except sqlite3.OperationalError as e:
+                if "duplicate column name" not in str(e).lower():
+                    raise
+                print(f"✅ language column already exists in {table}")
+
     # Update version
-    cursor.execute("INSERT OR REPLACE INTO schema_info (key, value) VALUES ('version', '7')")
+    cursor.execute("INSERT OR REPLACE INTO schema_info (key, value) VALUES ('version', '8')")
 
 def verify_schema(cursor):
     """Verify that all required tables and columns exist."""

--- a/models/__init__.py
+++ b/models/__init__.py
@@ -4,22 +4,28 @@ from db_models import (
     EnvironmentVariable,
     ScheduledJob,
     WebhookJob,
-    PersistentService, 
+    PersistentService,
     ExecutionLog,
     ExposedPort,
+    User,
+    ApiKey,
+    SYSTEM_USER_ID,
     SessionLocal,
     Base,
-    get_db
+    get_db,
 )
 
 __all__ = [
     "EnvironmentVariable",
-    "ScheduledJob", 
+    "ScheduledJob",
     "WebhookJob",
     "PersistentService",
-    "ExecutionLog", 
+    "ExecutionLog",
     "ExposedPort",
+    "User",
+    "ApiKey",
+    "SYSTEM_USER_ID",
     "SessionLocal",
     "Base",
-    "get_db"
-] 
+    "get_db",
+]

--- a/models/schemas.py
+++ b/models/schemas.py
@@ -193,4 +193,79 @@ class PersistentServiceResponse(BaseModel):
     restart_policy: str
     description: Optional[str]
     process_id: Optional[str]
-    auto_start: bool 
+    auto_start: bool
+
+
+# ---------------------------------------------------------------------
+# Auth / users / API keys
+# ---------------------------------------------------------------------
+
+
+class LoginRequest(BaseModel):
+    email: str
+    password: str
+
+
+class LoginResponse(BaseModel):
+    """Issued on successful login. `session_token` is also set as an
+    HttpOnly cookie; callers that prefer Authorization headers can use
+    the token directly."""
+
+    session_token: str
+    user: "UserResponse"
+
+
+class UserResponse(BaseModel):
+    id: int
+    email: str
+    is_admin: bool
+    disabled: bool
+    created_at: str
+
+
+class UserCreateRequest(BaseModel):
+    """Admin-only endpoint body for creating new users."""
+
+    email: str
+    password: str
+    is_admin: Optional[bool] = False
+
+
+class UserUpdateRequest(BaseModel):
+    """Admin-only endpoint body for updating a user.
+
+    All fields optional; pass only the ones you want to change. Setting
+    `password` to non-empty resets the user's password.
+    """
+
+    email: Optional[str] = None
+    password: Optional[str] = None
+    is_admin: Optional[bool] = None
+    disabled: Optional[bool] = None
+
+
+class ApiKeyCreateRequest(BaseModel):
+    label: Optional[str] = None
+
+
+class ApiKeyCreateResponse(BaseModel):
+    """Plaintext token is returned exactly once. Store it somewhere
+    durable immediately; the server only retains its hash."""
+
+    id: int
+    token: str
+    prefix: str
+    label: Optional[str]
+    created_at: str
+
+
+class ApiKeyResponse(BaseModel):
+    id: int
+    prefix: str
+    label: Optional[str]
+    last_used_at: Optional[str]
+    created_at: str
+
+
+LoginResponse.model_rebuild()
+ 

--- a/models/schemas.py
+++ b/models/schemas.py
@@ -8,6 +8,7 @@ class CodeExecutionRequest(BaseModel):
     packages: Optional[List[str]] = None
     timeout: Optional[int] = 30
     container_id: Optional[str] = None
+    language: Optional[str] = "python"
 
 class PackageInstallRequest(BaseModel):
     name: str
@@ -27,6 +28,7 @@ class ScheduledJobRequest(BaseModel):
     container_id: Optional[str] = None
     packages: Optional[List[str]] = None
     timeout: Optional[int] = 30
+    language: Optional[str] = "python"
 
 class ScheduledJobResponse(BaseModel):
     id: int
@@ -77,6 +79,7 @@ class WebhookJobRequest(BaseModel):
     packages: Optional[List[str]] = None
     timeout: Optional[int] = 30
     description: Optional[str] = None
+    language: Optional[str] = "python"
 
 class WebhookJobResponse(BaseModel):
     id: int
@@ -99,6 +102,7 @@ class PersistentServiceRequest(BaseModel):
     restart_policy: Optional[str] = "always"  # always, never, on-failure
     description: Optional[str] = None
     auto_start: Optional[bool] = True
+    language: Optional[str] = "python"
 
 class PersistentServiceResponse(BaseModel):
     id: int

--- a/models/schemas.py
+++ b/models/schemas.py
@@ -1,14 +1,56 @@
-from pydantic import BaseModel
+from pydantic import BaseModel, Field
 from typing import List, Optional
 from datetime import datetime
 
+
 class CodeExecutionRequest(BaseModel):
-    code: Optional[str] = None
-    job_id: Optional[int] = None
-    packages: Optional[List[str]] = None
-    timeout: Optional[int] = 30
-    container_id: Optional[str] = None
-    language: Optional[str] = "python"
+    """Body for `POST /execute` and `POST /execute-web-service`."""
+
+    code: Optional[str] = Field(
+        None,
+        description="Source to execute. If omitted, `job_id` must be set so "
+                    "the server can fetch the code from a scheduled job.",
+    )
+    job_id: Optional[int] = Field(
+        None,
+        description="Execute the code stored for this scheduled job. "
+                    "Mutually useful with an empty `code`.",
+    )
+    packages: Optional[List[str]] = Field(
+        None,
+        description="Package specifiers for the selected runtime's package "
+                    "manager. pip/npm/gem syntax supported; ignored for "
+                    "bash and go.",
+    )
+    timeout: Optional[int] = Field(
+        30,
+        description="Max execution wall-time in seconds.",
+    )
+    container_id: Optional[str] = Field(
+        None,
+        description="Legacy: run in this already-named container via docker "
+                    "exec. Bypasses the worker cache. Prefer omitting.",
+    )
+    language: Optional[str] = Field(
+        "python",
+        description="Runtime name (see `GET /languages`).",
+        examples=["python", "node", "ruby", "bash", "go"],
+    )
+
+    model_config = {
+        "json_schema_extra": {
+            "examples": [
+                {"code": "print('hello')", "language": "python",
+                 "packages": [], "timeout": 30},
+                {"code": "const _ = require('lodash'); "
+                         "console.log(_.sum([1,2,3,4]))",
+                 "language": "node", "packages": ["lodash"], "timeout": 60},
+                {"code": "echo \"bash $BASH_VERSION\"; uname -a",
+                 "language": "bash", "timeout": 10},
+            ]
+        }
+    }
+
 
 class PackageInstallRequest(BaseModel):
     name: str
@@ -22,13 +64,25 @@ class ContainerResponse(BaseModel):
     code: Optional[str] = None
 
 class ScheduledJobRequest(BaseModel):
-    name: str
-    code: str
-    cron_expression: str
+    """Body for `POST /jobs` and `PUT /jobs/{id}`."""
+
+    name: str = Field(..., description="Human-readable name for the job.")
+    code: str = Field(..., description="Source executed on every cron tick.")
+    cron_expression: str = Field(
+        ...,
+        description="Standard 5-field crontab (minute hour dom month dow).",
+        examples=["*/5 * * * *", "0 0 * * *"],
+    )
     container_id: Optional[str] = None
-    packages: Optional[List[str]] = None
-    timeout: Optional[int] = 30
-    language: Optional[str] = "python"
+    packages: Optional[List[str]] = Field(
+        None,
+        description="Package specifiers for the runtime's package manager.",
+    )
+    timeout: Optional[int] = Field(30, description="Max seconds per run.")
+    language: Optional[str] = Field(
+        "python",
+        description="Runtime name (see `GET /languages`).",
+    )
 
 class ScheduledJobResponse(BaseModel):
     id: int
@@ -74,14 +128,32 @@ class EnvVarMetadata(BaseModel):
     updated_at: str
 
 class WebhookJobRequest(BaseModel):
-    name: str
-    endpoint: str  # URL path like /webhook/my-job
-    code: str
+    """Body for `POST /webhook-jobs` and `PUT /webhook-jobs/{id}`.
+
+    Once created, the job is reachable at `/webhook/{endpoint}` via any
+    HTTP method. For Python jobs, the request is auto-wrapped: user code
+    has access to a `request_data` dict and should write the response
+    into a `response_data` variable. For other languages, request data
+    arrives via the `SUPAKILN_REQUEST_DATA` env var (JSON-encoded) and
+    the user code must print the JSON response to stdout.
+    """
+
+    name: str = Field(..., description="Human-readable name.")
+    endpoint: str = Field(
+        ...,
+        description="URL path the webhook is served under (leading slash "
+                    "optional). Final URL: `/webhook{endpoint}`.",
+        examples=["/stripe-events", "/github-ci"],
+    )
+    code: str = Field(..., description="Source executed on each request.")
     container_id: Optional[str] = None
     packages: Optional[List[str]] = None
-    timeout: Optional[int] = 30
+    timeout: Optional[int] = Field(30, description="Max seconds per call.")
     description: Optional[str] = None
-    language: Optional[str] = "python"
+    language: Optional[str] = Field(
+        "python",
+        description="Runtime name (see `GET /languages`).",
+    )
 
 class WebhookJobResponse(BaseModel):
     id: int

--- a/models/schemas.py
+++ b/models/schemas.py
@@ -33,6 +33,7 @@ class ScheduledJobRequest(BaseModel):
 class ScheduledJobResponse(BaseModel):
     id: int
     name: str
+    code: Optional[str] = None
     cron_expression: str
     container_id: Optional[str]
     packages: Optional[str]
@@ -40,6 +41,7 @@ class ScheduledJobResponse(BaseModel):
     last_run: Optional[str]
     is_active: bool
     timeout: int
+    language: Optional[str] = "python"
 
 class ExecutionLogResponse(BaseModel):
     id: int
@@ -93,6 +95,7 @@ class WebhookJobResponse(BaseModel):
     is_active: bool
     timeout: int
     description: Optional[str]
+    language: Optional[str] = "python"
 
 class PersistentServiceRequest(BaseModel):
     name: str

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,4 +9,5 @@ apscheduler==3.10.4
 python-dotenv==1.0.0
 cryptography==41.0.5
 httpx==0.25.2
-websockets==12.0 
+websockets==12.0
+argon2-cffi==23.1.0

--- a/routers/auth.py
+++ b/routers/auth.py
@@ -1,0 +1,121 @@
+"""Login / logout / self endpoints.
+
+Login issues an opaque session token stored in the api_keys table with
+kind='session' and an expires_at 14 days out. The token is returned in
+the response body AND set as an HttpOnly cookie for browser callers.
+Logout revokes the session row.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timedelta
+
+from fastapi import APIRouter, Depends, HTTPException, Request, Response, status
+from sqlalchemy.orm import Session
+
+from database import get_db
+from db_models import ApiKey, User
+from models.schemas import LoginRequest, LoginResponse, UserResponse
+from auth import (
+    current_user,
+    generate_token,
+    hash_token,
+    verify_password,
+    SESSION_TTL_SECONDS,
+)
+
+
+router = APIRouter(prefix="/auth", tags=["auth"])
+
+
+def _user_response(user: User) -> UserResponse:
+    return UserResponse(
+        id=user.id,
+        email=user.email,
+        is_admin=bool(user.is_admin),
+        disabled=bool(user.disabled),
+        created_at=user.created_at.isoformat() if user.created_at else "",
+    )
+
+
+@router.post("/login", response_model=LoginResponse, summary="Exchange email/password for a session token")
+async def login(
+    body: LoginRequest,
+    response: Response,
+    db: Session = Depends(get_db),
+):
+    user = db.query(User).filter(User.email == body.email).first()
+    # Keep the failure path uniform to avoid user-enumeration by timing.
+    if user is None or user.disabled or not user.password_hash:
+        # Still do a dummy verify to even out timing.
+        verify_password(
+            "$argon2id$v=19$m=65536,t=3,p=4$"
+            "dummy-salt-for-timing-pad$dummy-hash-for-timing",
+            body.password,
+        )
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail="invalid credentials",
+        )
+
+    if not verify_password(user.password_hash, body.password):
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail="invalid credentials",
+        )
+
+    plaintext, hashed, prefix = generate_token()
+    session = ApiKey(
+        user_id=user.id,
+        hashed_key=hashed,
+        prefix=prefix,
+        label="login session",
+        kind="session",
+        expires_at=datetime.utcnow() + timedelta(seconds=SESSION_TTL_SECONDS),
+    )
+    db.add(session)
+    db.commit()
+
+    response.set_cookie(
+        key="supakiln_session",
+        value=plaintext,
+        max_age=SESSION_TTL_SECONDS,
+        httponly=True,
+        samesite="lax",
+        # Secure flag intentionally not forced here: the deployment
+        # reverse-proxy (Cloudflare) terminates TLS. Local dev uses http.
+    )
+    return LoginResponse(
+        session_token=plaintext,
+        user=_user_response(user),
+    )
+
+
+@router.post("/logout", summary="Revoke the current session")
+async def logout(
+    request: Request,
+    response: Response,
+    db: Session = Depends(get_db),
+):
+    # Look at the same transports as the dep.
+    auth = request.headers.get("Authorization") or ""
+    token = None
+    if auth.lower().startswith("bearer "):
+        token = auth[7:].strip() or None
+    if not token:
+        token = request.cookies.get("supakiln_session")
+
+    if token:
+        hashed = hash_token(token)
+        key = db.query(ApiKey).filter(ApiKey.hashed_key == hashed).first()
+        if key is not None and key.revoked_at is None:
+            key.revoked_at = datetime.utcnow()
+            db.commit()
+
+    response.delete_cookie("supakiln_session")
+    return {"ok": True}
+
+
+@router.get("/me", response_model=UserResponse, summary="Current authenticated user")
+async def me(user: User = Depends(current_user)):
+    return _user_response(user)

--- a/routers/environment.py
+++ b/routers/environment.py
@@ -2,12 +2,14 @@ from fastapi import APIRouter, HTTPException, Depends
 from sqlalchemy.orm import Session
 from typing import List
 from models.schemas import EnvVarRequest, EnvVarResponse, EnvVarMetadata
-from models import EnvironmentVariable
+from models import EnvironmentVariable, User
 from database import get_db
 from env_manager import EnvironmentManager
+from auth import current_user
 import os
 
 router = APIRouter(prefix="/env", tags=["environment"])
+
 
 def get_env_manager():
     """Get environment manager instance."""
@@ -25,52 +27,81 @@ def get_env_manager():
     finally:
         db.close()
 
+
 @router.post("", response_model=EnvVarResponse)
-async def set_environment_variable(request: EnvVarRequest, db: Session = Depends(get_db)):
-    """Set an environment variable."""
+async def set_environment_variable(
+    request: EnvVarRequest,
+    db: Session = Depends(get_db),
+    user: User = Depends(current_user),
+):
+    """Set one of the caller's encrypted environment variables.
+
+    Each user has their own namespace — the same `name` can exist for
+    several users and will resolve independently.
+    """
     manager = get_env_manager()
-    manager.set_variable(request.name, request.value, request.description)
-    var = db.query(EnvironmentVariable).filter_by(name=request.name).first()
+    manager.set_variable(
+        request.name, request.value,
+        owner_user_id=user.id, description=request.description,
+    )
+    var = db.query(EnvironmentVariable).filter(
+        EnvironmentVariable.name == request.name,
+        EnvironmentVariable.owner_user_id == user.id,
+    ).first()
     return EnvVarResponse(
         name=var.name,
         created_at=var.created_at.isoformat(),
-        updated_at=var.updated_at.isoformat()
+        updated_at=var.updated_at.isoformat(),
     )
 
+
 @router.get("", response_model=List[str])
-async def list_environment_variables():
-    """List all environment variable names."""
+async def list_environment_variables(user: User = Depends(current_user)):
+    """List names of the caller's environment variables."""
     manager = get_env_manager()
-    return manager.list_variables()
+    return manager.list_variables(owner_user_id=user.id)
+
 
 @router.get("/metadata", response_model=List[EnvVarMetadata])
-async def list_environment_variable_metadata():
-    """List all environment variable metadata without values."""
+async def list_environment_variable_metadata(user: User = Depends(current_user)):
+    """List metadata for the caller's environment variables."""
     manager = get_env_manager()
-    return manager.list_variables_with_metadata()
+    return manager.list_variables_with_metadata(owner_user_id=user.id)
+
 
 @router.get("/metadata/{name}", response_model=EnvVarMetadata)
-async def get_environment_variable_metadata(name: str):
-    """Get an environment variable metadata without value."""
+async def get_environment_variable_metadata(
+    name: str,
+    user: User = Depends(current_user),
+):
+    """Get metadata of a specific env var (no value)."""
     manager = get_env_manager()
-    metadata = manager.get_variable_metadata(name)
+    metadata = manager.get_variable_metadata(name, owner_user_id=user.id)
     if metadata is None:
         raise HTTPException(status_code=404, detail="Environment variable not found")
     return metadata
 
+
 @router.get("/{name}")
-async def get_environment_variable(name: str):
-    """Get an environment variable value."""
+async def get_environment_variable(
+    name: str,
+    user: User = Depends(current_user),
+):
+    """Get the decrypted value of the caller's env var by name."""
     manager = get_env_manager()
-    value = manager.get_variable(name)
+    value = manager.get_variable(name, owner_user_id=user.id)
     if value is None:
         raise HTTPException(status_code=404, detail="Environment variable not found")
     return {"name": name, "value": value}
 
+
 @router.delete("/{name}")
-async def delete_environment_variable(name: str):
-    """Delete an environment variable."""
+async def delete_environment_variable(
+    name: str,
+    user: User = Depends(current_user),
+):
+    """Delete one of the caller's env vars."""
     manager = get_env_manager()
-    if not manager.delete_variable(name):
+    if not manager.delete_variable(name, owner_user_id=user.id):
         raise HTTPException(status_code=404, detail="Environment variable not found")
-    return {"message": f"Environment variable {name} deleted successfully"} 
+    return {"message": f"Environment variable {name} deleted successfully"}

--- a/routers/execution.py
+++ b/routers/execution.py
@@ -34,11 +34,15 @@ def get_env_manager():
     finally:
         db.close()
 
-@router.post("/execute-web-service")
+@router.post("/execute-web-service", summary="Start a Python web service")
 async def execute_web_service(request: CodeExecutionRequest, db: Session = Depends(get_db)):
-    """
-    Execute Python code specifically optimized for web services (Streamlit, FastAPI, Flask, Dash).
-    This endpoint always uses the CodeExecutor.execute_code method for proper web service detection.
+    """Execute Python code and detect if it's a web framework (Streamlit,
+    FastAPI, Flask, Dash, or Gradio) — if so, spin up a long-running
+    container, publish its port, and return a `proxy_url` under `/proxy/...`.
+
+    Effectively the same as `POST /execute` with `language=python`, but
+    with a 60s timeout and no language selection. Use `/execute` for
+    snippets; use this endpoint (or `POST /services`) for web apps.
     """
     start_time = time.time()
     try:
@@ -97,12 +101,36 @@ async def execute_web_service(request: CodeExecutionRequest, db: Session = Depen
         
         raise HTTPException(status_code=500, detail=error_msg)
 
-@router.post("/execute")
+@router.post("/execute", summary="Run code in the selected runtime")
 async def execute_code(request: CodeExecutionRequest, db: Session = Depends(get_db)):
-    """
-    Execute Python code in a container.
-    If container_id is provided, use that container.
-    Otherwise, create a new container with the specified packages.
+    """Execute a snippet in an isolated Docker container.
+
+    Picks a runtime from `request.language` (default `python`; call
+    `GET /languages` for the full list). The executor caches one worker
+    container per `(language, package_hash)` so repeat calls against the
+    same environment reuse a live HTTP worker — warm-path latency is
+    typically 10–30ms for interpreted languages.
+
+    **Body**
+    - `code` *(required)* — the source to execute
+    - `language` — `python` | `node` | `ruby` | `bash` | `go` (default `python`)
+    - `packages` — list of package specifiers for the runtime's package
+      manager (pip / npm / gem). Ignored for `bash` and `go`.
+    - `timeout` — seconds (default 30)
+    - `container_id` — if set, execute against an already-named container
+      via the legacy docker-exec path (bypasses the worker cache)
+
+    **Response**
+    - `success`: `bool`
+    - `output`: stdout as a string (or `null`)
+    - `error`: stderr or failure reason (or `null`)
+    - `container_id`: the worker container that ran this call
+    - `timed_out`: `bool`
+    - `timings_ms`: per-phase timing breakdown (cold vs. warm)
+    - `web_service`: present only when Python web-framework detection
+      fires; contains `type`, `external_port`, `proxy_url`
+
+    Returns `400` if the language isn't registered; `500` on other failures.
     """
     start_time = time.time()
     try:
@@ -320,19 +348,16 @@ async def execute_code(request: CodeExecutionRequest, db: Session = Depends(get_
         
         raise HTTPException(status_code=500, detail=error_msg)
 
-@router.get("/languages")
+@router.get("/languages", summary="List registered runtimes")
 async def list_languages():
-    """Return the set of runtimes the server can execute code in.
+    """Return the runtimes the server can execute code in.
 
-    Returns:
-        {
-          "languages": ["bash", "go", ...],  # names, kept for back-compat
-          "runtimes": [
-             {"name", "display_name", "file_extension",
-              "supports_packages", "package_manager"},
-             ...
-          ]
-        }
+    **Response**
+    - `languages`: array of runtime names — the authoritative list, kept
+      for back-compat with older clients.
+    - `runtimes`: array of `{name, display_name, file_extension,
+      supports_packages, package_manager}`. `supports_packages=false`
+      means the runtime has no package manager wired in (bash, go).
     """
     import languages as lang_registry
     names = lang_registry.names()

--- a/routers/execution.py
+++ b/routers/execution.py
@@ -1,16 +1,18 @@
 from fastapi import APIRouter, HTTPException, Depends
+from fastapi.concurrency import run_in_threadpool
 from sqlalchemy.orm import Session
 import time
 import base64
 from datetime import datetime
 import docker
 from models.schemas import CodeExecutionRequest
-from models import ScheduledJob, ExecutionLog
+from models import ScheduledJob, ExecutionLog, User
 from database import get_db
 from services.docker_client import docker_client
 from code_executor import CodeExecutor
 from env_manager import EnvironmentManager
 from services.code_executor_service import get_code_executor
+from auth import current_user
 import os
 
 router = APIRouter(tags=["execution"])
@@ -35,7 +37,11 @@ def get_env_manager():
         db.close()
 
 @router.post("/execute-web-service", summary="Start a Python web service")
-async def execute_web_service(request: CodeExecutionRequest, db: Session = Depends(get_db)):
+async def execute_web_service(
+    request: CodeExecutionRequest,
+    db: Session = Depends(get_db),
+    user: User = Depends(current_user),
+):
     """Execute Python code and detect if it's a web framework (Streamlit,
     FastAPI, Flask, Dash, or Gradio) — if so, spin up a long-running
     container, publish its port, and return a `proxy_url` under `/proxy/...`.
@@ -48,26 +54,32 @@ async def execute_web_service(request: CodeExecutionRequest, db: Session = Depen
     try:
         if not request.code:
             raise HTTPException(status_code=400, detail="Code is required")
-        
+
         if not request.packages:
             request.packages = []
-            
-        # Get environment variables
+
+        # Get environment variables scoped to the caller
         env_manager = get_env_manager()
-        env_vars = env_manager.get_all_variables()
-        
-        # Use the CodeExecutor method which handles web service detection
-        result = get_code_executor().execute_code(
+        env_vars = env_manager.get_all_variables(owner_user_id=user.id)
+
+        # `execute_code` is sync and blocking (talks to the worker over
+        # HTTP with `requests`). Dispatch it to a threadpool so the
+        # uvicorn event loop stays free to accept other requests — two
+        # users submitting simultaneously actually run concurrently.
+        result = await run_in_threadpool(
+            get_code_executor().execute_code,
             code=request.code,
             packages=request.packages,
             timeout=60,  # Longer timeout for web services
-            env_vars=env_vars
+            env_vars=env_vars,
+            user_id=user.id,
         )
-        
+
         # Log the execution
         container_id = result.get("container_id")
         log = ExecutionLog(
             job_id=request.job_id if hasattr(request, 'job_id') else None,
+            owner_user_id=user.id,
             code=request.code,
             output=result.get("output"),
             error=result.get("error"),
@@ -78,15 +90,24 @@ async def execute_web_service(request: CodeExecutionRequest, db: Session = Depen
         )
         db.add(log)
         db.commit()
-        
+
+        # Cap-induced failure surfaces as HTTP 429 / 503 so clients can
+        # back off and retry rather than treating it as a 500.
+        if result.get("http_status"):
+            raise HTTPException(
+                status_code=result["http_status"],
+                detail=result.get("error") or "capacity exceeded",
+            )
+
         return result
-        
+
     except Exception as e:
         error_msg = str(e) if str(e) else f"Unknown error: {type(e).__name__}"
-        
-        try:        
+
+        try:
             log = ExecutionLog(
                 job_id=getattr(request, 'job_id', None) if 'request' in locals() else None,
+                owner_user_id=user.id,
                 code=getattr(request, 'code', None) if 'request' in locals() else None,
                 error=error_msg,
                 execution_time=time.time() - start_time,
@@ -98,18 +119,23 @@ async def execute_web_service(request: CodeExecutionRequest, db: Session = Depen
         except Exception as log_error:
             print(f"Failed to log error: {log_error}")
             print(f"Original error: {error_msg}")
-        
+
         raise HTTPException(status_code=500, detail=error_msg)
 
 @router.post("/execute", summary="Run code in the selected runtime")
-async def execute_code(request: CodeExecutionRequest, db: Session = Depends(get_db)):
+async def execute_code(
+    request: CodeExecutionRequest,
+    db: Session = Depends(get_db),
+    user: User = Depends(current_user),
+):
     """Execute a snippet in an isolated Docker container.
 
     Picks a runtime from `request.language` (default `python`; call
     `GET /languages` for the full list). The executor caches one worker
-    container per `(language, package_hash)` so repeat calls against the
-    same environment reuse a live HTTP worker — warm-path latency is
-    typically 10–30ms for interpreted languages.
+    container per `(language, user, package_hash)` so repeat calls against
+    the same environment reuse a live HTTP worker — warm-path latency is
+    typically 10–30ms for interpreted languages. Each user gets their
+    own worker container; no state crosses users.
 
     **Body**
     - `code` *(required)* — the source to execute
@@ -137,11 +163,11 @@ async def execute_code(request: CodeExecutionRequest, db: Session = Depends(get_
         # If code is not provided in request but we have a job_id, get code from the job
         if not request.code and hasattr(request, 'job_id'):
             job = db.query(ScheduledJob).filter(ScheduledJob.id == request.job_id).first()
-            if job:
+            if job and (user.is_admin or job.owner_user_id == user.id):
                 request.code = job.code
             else:
                 raise HTTPException(status_code=404, detail="Job not found")
-        
+
         if not request.code:
             raise HTTPException(status_code=400, detail="Code is required")
 
@@ -149,7 +175,7 @@ async def execute_code(request: CodeExecutionRequest, db: Session = Depends(get_
             # Verify container exists
             if request.container_id not in get_code_executor().containers.values():
                 raise HTTPException(status_code=404, detail="Container not found")
-            
+
             # Execute in existing container
             try:
                 container = docker_client.containers.get(request.container_id)
@@ -157,23 +183,23 @@ async def execute_code(request: CodeExecutionRequest, db: Session = Depends(get_
                 raise HTTPException(status_code=404, detail="Container not found in Docker")
             except Exception as e:
                 raise HTTPException(status_code=500, detail=f"Error accessing container: {str(e)}")
-            
-            # Get environment variables
+
+            # Get environment variables scoped to the caller
             env_manager = get_env_manager()
-            env_vars = env_manager.get_all_variables()
-            
+            env_vars = env_manager.get_all_variables(owner_user_id=user.id)
+
             # Encode the code in base64
             encoded_code = base64.b64encode(request.code.encode()).decode()
-            
+
             # Execute with streaming output and timeout handling
             output_buffer = []
             error_buffer = []
             success = False
             timed_out = False
-            
+
             import threading
             import signal
-            
+
             def collect_output():
                 nonlocal success, timed_out
                 try:
@@ -184,7 +210,7 @@ async def execute_code(request: CodeExecutionRequest, db: Session = Depends(get_
                         stream=False,  # Don't stream to get proper exit code
                         demux=True    # Separate stdout and stderr
                     )
-                    
+
                     # Process the output
                     if result.output:
                         stdout_data, stderr_data = result.output
@@ -192,23 +218,23 @@ async def execute_code(request: CodeExecutionRequest, db: Session = Depends(get_
                             output_buffer.append(stdout_data.decode('utf-8', errors='replace'))
                         if stderr_data:
                             error_buffer.append(stderr_data.decode('utf-8', errors='replace'))
-                    
+
                     # Now we can reliably check the exit code
                     success = result.exit_code == 0
-                    
+
                 except Exception as e:
                     error_buffer.append(f"Execution error: {str(e)}")
                     success = False
-            
+
             # Start output collection in a separate thread
             output_thread = threading.Thread(target=collect_output)
             output_thread.daemon = True
             output_thread.start()
-            
+
             # Wait for completion or timeout
             timeout_seconds = request.timeout or 30
             output_thread.join(timeout_seconds)
-            
+
             if output_thread.is_alive():
                 # Thread is still running, so we timed out
                 timed_out = True
@@ -218,14 +244,14 @@ async def execute_code(request: CodeExecutionRequest, db: Session = Depends(get_
                     container.exec_run("pkill -f python", detach=True)
                 except:
                     pass
-                
+
                 # Give it a moment to clean up
                 output_thread.join(1)
-            
+
             # Combine output
             combined_output = ''.join(output_buffer) if output_buffer else None
             combined_error = ''.join(error_buffer) if error_buffer else None
-            
+
             # If we timed out, add timeout message
             if timed_out:
                 timeout_msg = f"\n--- Execution timed out after {timeout_seconds} seconds ---"
@@ -236,10 +262,11 @@ async def execute_code(request: CodeExecutionRequest, db: Session = Depends(get_
                 else:
                     combined_error = f"Execution timed out after {timeout_seconds} seconds"
                 success = False
-            
+
             # Log the execution
             log = ExecutionLog(
                 job_id=request.job_id if hasattr(request, 'job_id') else None,
+                owner_user_id=user.id,
                 code=request.code,
                 output=combined_output,
                 error=combined_error,
@@ -250,7 +277,7 @@ async def execute_code(request: CodeExecutionRequest, db: Session = Depends(get_
             )
             db.add(log)
             db.commit()
-            
+
             return {
                 "success": success and not timed_out,
                 "output": combined_output,
@@ -276,23 +303,27 @@ async def execute_code(request: CodeExecutionRequest, db: Session = Depends(get_
                     detail=f"unknown language {language!r}; known: {lang_registry.names()}",
                 )
 
-            # Get environment variables
+            # Get environment variables scoped to the caller
             env_manager = get_env_manager()
-            env_vars = env_manager.get_all_variables()
+            env_vars = env_manager.get_all_variables(owner_user_id=user.id)
 
-            # Use the proper executor method
-            result = get_code_executor().execute_code(
+            # Offload the blocking executor call so concurrent /execute
+            # requests don't serialize on the asyncio event loop.
+            result = await run_in_threadpool(
+                get_code_executor().execute_code,
                 code=request.code,
                 packages=request.packages,
                 timeout=request.timeout or 30,
                 env_vars=env_vars,
                 language=language,
+                user_id=user.id,
             )
-            
+
             # Log the execution
             container_id = result.get("container_id")
             log = ExecutionLog(
                 job_id=request.job_id if hasattr(request, 'job_id') else None,
+                owner_user_id=user.id,
                 code=request.code,
                 output=result.get("output"),
                 error=result.get("error"),
@@ -303,7 +334,15 @@ async def execute_code(request: CodeExecutionRequest, db: Session = Depends(get_
             )
             db.add(log)
             db.commit()
-            
+
+            # Cap-induced failure surfaces as HTTP 429 / 503 so clients
+            # can back off and retry rather than treating it as a 500.
+            if result.get("http_status"):
+                raise HTTPException(
+                    status_code=result["http_status"],
+                    detail=result.get("error") or "capacity exceeded",
+                )
+
             # Return the result from CodeExecutor with additional info
             response = {
                 "success": result.get("success"),
@@ -328,11 +367,12 @@ async def execute_code(request: CodeExecutionRequest, db: Session = Depends(get_
     except Exception as e:
         # Create a more descriptive error message
         error_msg = str(e) if str(e) else f"Unknown error: {type(e).__name__}"
-        
+
         # Log the error with safe attribute access
         try:
             log = ExecutionLog(
                 job_id=getattr(request, 'job_id', None) if 'request' in locals() else None,
+                owner_user_id=user.id,
                 code=getattr(request, 'code', None) if 'request' in locals() else None,
                 error=error_msg,
                 execution_time=time.time() - start_time,
@@ -345,7 +385,7 @@ async def execute_code(request: CodeExecutionRequest, db: Session = Depends(get_
             # If logging fails, at least print the error
             print(f"Failed to log error: {log_error}")
             print(f"Original error: {error_msg}")
-        
+
         raise HTTPException(status_code=500, detail=error_msg)
 
 @router.get("/languages", summary="List registered runtimes")
@@ -399,7 +439,7 @@ async def debug_containers():
                     "container_id": container_id,
                     "error": str(e)
                 })
-        
+
         web_services_info = []
         for container_id, service_info in get_code_executor().web_service_containers.items():
             web_services_info.append({
@@ -410,7 +450,7 @@ async def debug_containers():
                 "external_port": service_info["external_port"],
                 "start_command": service_info["start_command"]
             })
-        
+
         return {
             "containers": containers_info,
             "web_services": web_services_info,
@@ -432,15 +472,15 @@ async def get_container_logs(container_id: str):
             if stored_id.startswith(container_id) or stored_id == container_id:
                 full_container_id = stored_id
                 break
-        
+
         if not full_container_id:
             raise HTTPException(status_code=404, detail="Container not found")
-        
+
         container = docker_client.containers.get(full_container_id)
-        
+
         # Get container logs
         logs = container.logs(tail=50).decode('utf-8', errors='replace')
-        
+
         # If it's a web service, also try to get the service log
         service_log = ""
         if full_container_id in get_code_executor().web_service_containers:
@@ -450,7 +490,7 @@ async def get_container_logs(container_id: str):
                     service_log = result.output.decode('utf-8', errors='replace')
             except Exception as e:
                 service_log = f"Error reading service log: {e}"
-        
+
         return {
             "container_id": full_container_id,
             "container_short_id": full_container_id[:8],
@@ -459,4 +499,4 @@ async def get_container_logs(container_id: str):
             "is_web_service": full_container_id in get_code_executor().web_service_containers
         }
     except Exception as e:
-        raise HTTPException(status_code=500, detail=f"Error getting logs: {str(e)}") 
+        raise HTTPException(status_code=500, detail=f"Error getting logs: {str(e)}")

--- a/routers/execution.py
+++ b/routers/execution.py
@@ -322,9 +322,31 @@ async def execute_code(request: CodeExecutionRequest, db: Session = Depends(get_
 
 @router.get("/languages")
 async def list_languages():
-    """Return the set of runtimes the server can execute code in."""
+    """Return the set of runtimes the server can execute code in.
+
+    Returns:
+        {
+          "languages": ["bash", "go", ...],  # names, kept for back-compat
+          "runtimes": [
+             {"name", "display_name", "file_extension",
+              "supports_packages", "package_manager"},
+             ...
+          ]
+        }
+    """
     import languages as lang_registry
-    return {"languages": lang_registry.names()}
+    names = lang_registry.names()
+    runtimes = []
+    for n in names:
+        rt = lang_registry.get(n)
+        runtimes.append({
+            "name": rt.name,
+            "display_name": rt.display_name or rt.name.title(),
+            "file_extension": rt.file_extension,
+            "supports_packages": rt.supports_packages,
+            "package_manager": rt.package_manager,
+        })
+    return {"languages": names, "runtimes": runtimes}
 
 
 @router.get("/debug/containers")

--- a/routers/execution.py
+++ b/routers/execution.py
@@ -271,11 +271,15 @@ async def execute_code(request: CodeExecutionRequest, db: Session = Depends(get_
                 "container_id": container_id,
                 "container_name": container_names.get(container_id, "Unnamed")
             }
-            
+
             # Include web service info if available
             if "web_service" in result:
                 response["web_service"] = result["web_service"]
-            
+
+            # Pass through timing breakdown for benchmarks/profiling
+            if "timings_ms" in result:
+                response["timings_ms"] = result["timings_ms"]
+
             return response
     except HTTPException:
         # Re-raise HTTPExceptions (like 404, 400, etc.) without catching them

--- a/routers/execution.py
+++ b/routers/execution.py
@@ -245,7 +245,8 @@ async def execute_code(request: CodeExecutionRequest, db: Session = Depends(get_
                 code=request.code,
                 packages=request.packages,
                 timeout=request.timeout or 30,
-                env_vars=env_vars
+                env_vars=env_vars,
+                language=request.language or "python",
             )
             
             # Log the execution
@@ -306,6 +307,13 @@ async def execute_code(request: CodeExecutionRequest, db: Session = Depends(get_
             print(f"Original error: {error_msg}")
         
         raise HTTPException(status_code=500, detail=error_msg)
+
+@router.get("/languages")
+async def list_languages():
+    """Return the set of runtimes the server can execute code in."""
+    import languages as lang_registry
+    return {"languages": lang_registry.names()}
+
 
 @router.get("/debug/containers")
 async def debug_containers():

--- a/routers/execution.py
+++ b/routers/execution.py
@@ -235,18 +235,30 @@ async def execute_code(request: CodeExecutionRequest, db: Session = Depends(get_
             # Use the CodeExecutor.execute_code method which handles web service detection
             if not request.packages:
                 request.packages = []
-            
+
+            # Validate language up front so we can 400 instead of
+            # bubbling up the KeyError as a 500.
+            import languages as lang_registry
+            language = request.language or "python"
+            try:
+                lang_registry.get(language)
+            except KeyError:
+                raise HTTPException(
+                    status_code=400,
+                    detail=f"unknown language {language!r}; known: {lang_registry.names()}",
+                )
+
             # Get environment variables
             env_manager = get_env_manager()
             env_vars = env_manager.get_all_variables()
-            
+
             # Use the proper executor method
             result = get_code_executor().execute_code(
                 code=request.code,
                 packages=request.packages,
                 timeout=request.timeout or 30,
                 env_vars=env_vars,
-                language=request.language or "python",
+                language=language,
             )
             
             # Log the execution

--- a/routers/jobs.py
+++ b/routers/jobs.py
@@ -6,14 +6,45 @@ from models.schemas import ScheduledJobRequest, ScheduledJobResponse
 from models import ScheduledJob
 from database import get_db
 from scheduler import scheduler
+import languages as lang_registry
 
 router = APIRouter(prefix="/jobs", tags=["scheduled-jobs"])
+
+
+def _validate_language(name: str) -> str:
+    """Return the validated language name or raise 400."""
+    if name is None:
+        return "python"
+    try:
+        return lang_registry.get(name).name
+    except KeyError:
+        raise HTTPException(
+            status_code=400,
+            detail=f"unknown language {name!r}; known: {lang_registry.names()}",
+        )
+
+
+def _job_to_response(job: ScheduledJob) -> dict:
+    return {
+        "id": job.id,
+        "name": job.name,
+        "code": job.code,
+        "cron_expression": job.cron_expression,
+        "packages": job.packages,
+        "container_id": job.container_id,
+        "created_at": job.created_at.isoformat(),
+        "last_run": job.last_run.isoformat() if job.last_run else None,
+        "is_active": bool(job.is_active),
+        "timeout": job.timeout,
+        "language": getattr(job, "language", None) or "python",
+    }
+
 
 @router.post("", response_model=ScheduledJobResponse)
 async def create_scheduled_job(request: ScheduledJobRequest, db: Session = Depends(get_db)):
     """Create a new scheduled job."""
+    language = _validate_language(request.language)
     try:
-        # Create job in database
         db_job = ScheduledJob(
             name=request.name,
             code=request.code,
@@ -21,53 +52,30 @@ async def create_scheduled_job(request: ScheduledJobRequest, db: Session = Depen
             packages=','.join(request.packages) if request.packages else None,
             container_id=request.container_id,
             timeout=request.timeout,
+            language=language,
             created_at=datetime.now(),
-            is_active=True
+            is_active=True,
         )
         db.add(db_job)
         db.commit()
         db.refresh(db_job)
-        
+
         # The scheduler will pick up the new job through load_existing_jobs
         scheduler.load_existing_jobs()
-        
-        # Convert datetime fields to ISO format strings for response
-        return {
-            "id": db_job.id,
-            "name": db_job.name,
-            "code": db_job.code,
-            "cron_expression": db_job.cron_expression,
-            "packages": db_job.packages,
-            "container_id": db_job.container_id,
-            "created_at": db_job.created_at.isoformat(),
-            "last_run": db_job.last_run.isoformat() if db_job.last_run else None,
-            "is_active": db_job.is_active,
-            "timeout": db_job.timeout
-        }
+
+        return _job_to_response(db_job)
+    except HTTPException:
+        raise
     except Exception as e:
         db.rollback()
         raise HTTPException(status_code=500, detail=str(e))
+
 
 @router.get("", response_model=List[ScheduledJobResponse])
 async def list_scheduled_jobs(db: Session = Depends(get_db)):
     """List all scheduled jobs."""
     jobs = db.query(ScheduledJob).all()
-    # Convert datetime fields to ISO format strings
-    return [
-        {
-            "id": job.id,
-            "name": job.name,
-            "code": job.code,
-            "cron_expression": job.cron_expression,
-            "packages": job.packages,
-            "container_id": job.container_id,
-            "created_at": job.created_at.isoformat(),
-            "last_run": job.last_run.isoformat() if job.last_run else None,
-            "is_active": job.is_active,
-            "timeout": job.timeout
-        }
-        for job in jobs
-    ]
+    return [_job_to_response(job) for job in jobs]
 
 @router.get("/{job_id}", response_model=ScheduledJobResponse)
 async def get_scheduled_job(job_id: int, db: Session = Depends(get_db)):
@@ -80,6 +88,7 @@ async def get_scheduled_job(job_id: int, db: Session = Depends(get_db)):
 @router.put("/{job_id}", response_model=ScheduledJobResponse)
 async def update_scheduled_job(job_id: int, request: ScheduledJobRequest, db: Session = Depends(get_db)):
     """Update a scheduled job."""
+    language = _validate_language(request.language)
     try:
         job = scheduler.update_job(
             job_id,
@@ -88,11 +97,14 @@ async def update_scheduled_job(job_id: int, request: ScheduledJobRequest, db: Se
             cron_expression=request.cron_expression,
             container_id=request.container_id,
             packages=','.join(request.packages) if request.packages else None,
-            timeout=request.timeout
+            timeout=request.timeout,
+            language=language,
         )
         if not job:
             raise HTTPException(status_code=404, detail="Job not found")
-        return job
+        return _job_to_response(job)
+    except HTTPException:
+        raise
     except Exception as e:
         raise HTTPException(status_code=500, detail=str(e))
 

--- a/routers/jobs.py
+++ b/routers/jobs.py
@@ -3,9 +3,10 @@ from sqlalchemy.orm import Session
 from typing import List
 from datetime import datetime
 from models.schemas import ScheduledJobRequest, ScheduledJobResponse
-from models import ScheduledJob
+from models import ScheduledJob, User
 from database import get_db
 from scheduler import scheduler
+from auth import current_user
 import languages as lang_registry
 
 router = APIRouter(prefix="/jobs", tags=["scheduled-jobs"])
@@ -40,8 +41,23 @@ def _job_to_response(job: ScheduledJob) -> dict:
     }
 
 
+def _scoped(db: Session, user: User):
+    """Return a query filtered to rows the user can see.
+
+    Admins see every job; non-admins only see their own.
+    """
+    q = db.query(ScheduledJob)
+    if not user.is_admin:
+        q = q.filter(ScheduledJob.owner_user_id == user.id)
+    return q
+
+
 @router.post("", response_model=ScheduledJobResponse)
-async def create_scheduled_job(request: ScheduledJobRequest, db: Session = Depends(get_db)):
+async def create_scheduled_job(
+    request: ScheduledJobRequest,
+    db: Session = Depends(get_db),
+    user: User = Depends(current_user),
+):
     """Create a new scheduled job."""
     language = _validate_language(request.language)
     try:
@@ -55,6 +71,7 @@ async def create_scheduled_job(request: ScheduledJobRequest, db: Session = Depen
             language=language,
             created_at=datetime.now(),
             is_active=True,
+            owner_user_id=user.id,
         )
         db.add(db_job)
         db.commit()
@@ -72,23 +89,41 @@ async def create_scheduled_job(request: ScheduledJobRequest, db: Session = Depen
 
 
 @router.get("", response_model=List[ScheduledJobResponse])
-async def list_scheduled_jobs(db: Session = Depends(get_db)):
-    """List all scheduled jobs."""
-    jobs = db.query(ScheduledJob).all()
+async def list_scheduled_jobs(
+    db: Session = Depends(get_db),
+    user: User = Depends(current_user),
+):
+    """List scheduled jobs owned by the caller (admins see all)."""
+    jobs = _scoped(db, user).all()
     return [_job_to_response(job) for job in jobs]
 
+
 @router.get("/{job_id}", response_model=ScheduledJobResponse)
-async def get_scheduled_job(job_id: int, db: Session = Depends(get_db)):
+async def get_scheduled_job(
+    job_id: int,
+    db: Session = Depends(get_db),
+    user: User = Depends(current_user),
+):
     """Get a specific scheduled job."""
-    job = db.query(ScheduledJob).filter(ScheduledJob.id == job_id).first()
+    job = _scoped(db, user).filter(ScheduledJob.id == job_id).first()
     if not job:
         raise HTTPException(status_code=404, detail="Job not found")
-    return job
+    return _job_to_response(job)
+
 
 @router.put("/{job_id}", response_model=ScheduledJobResponse)
-async def update_scheduled_job(job_id: int, request: ScheduledJobRequest, db: Session = Depends(get_db)):
+async def update_scheduled_job(
+    job_id: int,
+    request: ScheduledJobRequest,
+    db: Session = Depends(get_db),
+    user: User = Depends(current_user),
+):
     """Update a scheduled job."""
     language = _validate_language(request.language)
+    # Verify ownership before letting the scheduler update anything.
+    existing = _scoped(db, user).filter(ScheduledJob.id == job_id).first()
+    if not existing:
+        raise HTTPException(status_code=404, detail="Job not found")
     try:
         job = scheduler.update_job(
             job_id,
@@ -108,11 +143,19 @@ async def update_scheduled_job(job_id: int, request: ScheduledJobRequest, db: Se
     except Exception as e:
         raise HTTPException(status_code=500, detail=str(e))
 
+
 @router.delete("/{job_id}")
-async def delete_scheduled_job(job_id: int):
+async def delete_scheduled_job(
+    job_id: int,
+    db: Session = Depends(get_db),
+    user: User = Depends(current_user),
+):
     """Delete a scheduled job."""
+    existing = _scoped(db, user).filter(ScheduledJob.id == job_id).first()
+    if not existing:
+        raise HTTPException(status_code=404, detail="Job not found")
     try:
         scheduler.delete_job(job_id)
         return {"message": "Job deleted successfully"}
     except Exception as e:
-        raise HTTPException(status_code=500, detail=str(e)) 
+        raise HTTPException(status_code=500, detail=str(e))

--- a/routers/logs.py
+++ b/routers/logs.py
@@ -2,10 +2,19 @@ from fastapi import APIRouter, HTTPException, Depends
 from sqlalchemy.orm import Session
 from typing import List, Optional
 from models.schemas import ExecutionLogResponse
-from models import ExecutionLog
+from models import ExecutionLog, User
 from database import get_db
+from auth import current_user
 
 router = APIRouter(prefix="/logs", tags=["logs"])
+
+
+def _scoped(db: Session, user: User):
+    q = db.query(ExecutionLog)
+    if not user.is_admin:
+        q = q.filter(ExecutionLog.owner_user_id == user.id)
+    return q
+
 
 @router.get("", response_model=List[ExecutionLogResponse])
 async def get_execution_logs(
@@ -13,17 +22,17 @@ async def get_execution_logs(
     webhook_job_id: Optional[int] = None,
     limit: int = 100,
     offset: int = 0,
-    db: Session = Depends(get_db)
+    db: Session = Depends(get_db),
+    user: User = Depends(current_user),
 ):
-    """Get execution logs with optional filtering."""
-    query = db.query(ExecutionLog)
+    """Get execution logs the caller owns (admins see all)."""
+    query = _scoped(db, user)
     if job_id is not None:
         query = query.filter(ExecutionLog.job_id == job_id)
     if webhook_job_id is not None:
         query = query.filter(ExecutionLog.webhook_job_id == webhook_job_id)
     logs = query.order_by(ExecutionLog.started_at.desc()).offset(offset).limit(limit).all()
-    
-    # Convert logs to response format with datetime as ISO string
+
     return [
         {
             "id": log.id,
@@ -37,19 +46,23 @@ async def get_execution_logs(
             "started_at": log.started_at.isoformat() if log.started_at else None,
             "status": log.status,
             "request_data": log.request_data,
-            "response_data": log.response_data
+            "response_data": log.response_data,
         }
         for log in logs
     ]
 
+
 @router.get("/{log_id}", response_model=ExecutionLogResponse)
-async def get_execution_log(log_id: int, db: Session = Depends(get_db)):
+async def get_execution_log(
+    log_id: int,
+    db: Session = Depends(get_db),
+    user: User = Depends(current_user),
+):
     """Get a specific execution log."""
-    log = db.query(ExecutionLog).filter(ExecutionLog.id == log_id).first()
+    log = _scoped(db, user).filter(ExecutionLog.id == log_id).first()
     if not log:
         raise HTTPException(status_code=404, detail="Log not found")
-    
-    # Convert log to response format with datetime as ISO string
+
     return {
         "id": log.id,
         "job_id": log.job_id,
@@ -62,5 +75,5 @@ async def get_execution_log(log_id: int, db: Session = Depends(get_db)):
         "started_at": log.started_at.isoformat() if log.started_at else None,
         "status": log.status,
         "request_data": log.request_data,
-        "response_data": log.response_data
-    } 
+        "response_data": log.response_data,
+    }

--- a/routers/services.py
+++ b/routers/services.py
@@ -3,22 +3,40 @@ from sqlalchemy.orm import Session
 from typing import List
 from datetime import datetime
 from models.schemas import PersistentServiceRequest, PersistentServiceResponse
-from models import PersistentService
+from models import PersistentService, User
 from database import get_db
 from services.service_manager import service_manager
 from services.docker_client import docker_client
+from auth import current_user
 
 router = APIRouter(prefix="/services", tags=["persistent-services"])
 
+
+def _scoped(db: Session, user: User):
+    q = db.query(PersistentService)
+    if not user.is_admin:
+        q = q.filter(PersistentService.owner_user_id == user.id)
+    return q
+
+
 @router.post("", response_model=PersistentServiceResponse)
-async def create_persistent_service(request: PersistentServiceRequest, db: Session = Depends(get_db)):
+async def create_persistent_service(
+    request: PersistentServiceRequest,
+    db: Session = Depends(get_db),
+    user: User = Depends(current_user),
+):
     """Create a new persistent service."""
     try:
-        # Check if name already exists
-        existing = db.query(PersistentService).filter(PersistentService.name == request.name).first()
+        # Service name is unique per-user (not globally); the caller's
+        # own services must not collide, but alice and bob can both
+        # have one named "worker".
+        existing = db.query(PersistentService).filter(
+            PersistentService.name == request.name,
+            PersistentService.owner_user_id == user.id,
+        ).first()
         if existing:
             raise HTTPException(status_code=400, detail="Service name already exists")
-        
+
         # Create service in database
         db_service = PersistentService(
             name=request.name,
@@ -30,7 +48,8 @@ async def create_persistent_service(request: PersistentServiceRequest, db: Sessi
             auto_start=1 if request.auto_start else 0,
             created_at=datetime.now(),
             is_active=True,
-            status="stopped"
+            status="stopped",
+            owner_user_id=user.id,
         )
         db.add(db_service)
         db.commit()
@@ -57,9 +76,12 @@ async def create_persistent_service(request: PersistentServiceRequest, db: Sessi
         raise HTTPException(status_code=500, detail=str(e))
 
 @router.get("", response_model=List[PersistentServiceResponse])
-async def list_persistent_services(db: Session = Depends(get_db)):
-    """List all persistent services."""
-    services = db.query(PersistentService).all()
+async def list_persistent_services(
+    db: Session = Depends(get_db),
+    user: User = Depends(current_user),
+):
+    """List persistent services owned by the caller (admins see all)."""
+    services = _scoped(db, user).all()
     return [
         {
             "id": service.id,
@@ -81,9 +103,13 @@ async def list_persistent_services(db: Session = Depends(get_db)):
     ]
 
 @router.get("/{service_id}", response_model=PersistentServiceResponse)
-async def get_persistent_service(service_id: int, db: Session = Depends(get_db)):
+async def get_persistent_service(
+    service_id: int,
+    db: Session = Depends(get_db),
+    user: User = Depends(current_user),
+):
     """Get a specific persistent service."""
-    service = db.query(PersistentService).filter(PersistentService.id == service_id).first()
+    service = _scoped(db, user).filter(PersistentService.id == service_id).first()
     if not service:
         raise HTTPException(status_code=404, detail="Service not found")
     return {
@@ -104,17 +130,23 @@ async def get_persistent_service(service_id: int, db: Session = Depends(get_db))
     }
 
 @router.put("/{service_id}", response_model=PersistentServiceResponse)
-async def update_persistent_service(service_id: int, request: PersistentServiceRequest, db: Session = Depends(get_db)):
+async def update_persistent_service(
+    service_id: int,
+    request: PersistentServiceRequest,
+    db: Session = Depends(get_db),
+    user: User = Depends(current_user),
+):
     """Update a persistent service."""
     try:
-        service = db.query(PersistentService).filter(PersistentService.id == service_id).first()
+        service = _scoped(db, user).filter(PersistentService.id == service_id).first()
         if not service:
             raise HTTPException(status_code=404, detail="Service not found")
-        
-        # Check if name already exists (excluding current service)
+
+        # Name is unique per-owner; check only within the caller's namespace.
         existing = db.query(PersistentService).filter(
             PersistentService.name == request.name,
-            PersistentService.id != service_id
+            PersistentService.owner_user_id == service.owner_user_id,
+            PersistentService.id != service_id,
         ).first()
         if existing:
             raise HTTPException(status_code=400, detail="Service name already exists")
@@ -152,10 +184,14 @@ async def update_persistent_service(service_id: int, request: PersistentServiceR
         raise HTTPException(status_code=500, detail=str(e))
 
 @router.delete("/{service_id}")
-async def delete_persistent_service(service_id: int, db: Session = Depends(get_db)):
+async def delete_persistent_service(
+    service_id: int,
+    db: Session = Depends(get_db),
+    user: User = Depends(current_user),
+):
     """Delete a persistent service."""
     try:
-        service = db.query(PersistentService).filter(PersistentService.id == service_id).first()
+        service = _scoped(db, user).filter(PersistentService.id == service_id).first()
         if not service:
             raise HTTPException(status_code=404, detail="Service not found")
         
@@ -172,46 +208,79 @@ async def delete_persistent_service(service_id: int, db: Session = Depends(get_d
 
 # Service control endpoints
 @router.post("/{service_id}/start")
-async def start_persistent_service(service_id: int, db: Session = Depends(get_db)):
+async def start_persistent_service(
+    service_id: int,
+    db: Session = Depends(get_db),
+    user: User = Depends(current_user),
+):
     """Start a persistent service."""
     try:
+        # Enforce ownership before touching the manager.
+        svc = _scoped(db, user).filter(PersistentService.id == service_id).first()
+        if not svc:
+            raise HTTPException(status_code=404, detail="Service not found")
         success = service_manager.start_service(service_id, db)
         if success:
             return {"message": "Service start initiated"}
-        else:
-            raise HTTPException(status_code=404, detail="Service not found")
+        raise HTTPException(status_code=404, detail="Service not found")
+    except HTTPException:
+        raise
     except Exception as e:
         raise HTTPException(status_code=500, detail=str(e))
 
+
 @router.post("/{service_id}/stop")
-async def stop_persistent_service(service_id: int, db: Session = Depends(get_db)):
+async def stop_persistent_service(
+    service_id: int,
+    db: Session = Depends(get_db),
+    user: User = Depends(current_user),
+):
     """Stop a persistent service."""
     try:
+        svc = _scoped(db, user).filter(PersistentService.id == service_id).first()
+        if not svc:
+            raise HTTPException(status_code=404, detail="Service not found")
         success = service_manager.stop_service(service_id, db)
         if success:
             return {"message": "Service stopped"}
-        else:
-            raise HTTPException(status_code=404, detail="Service not found")
+        raise HTTPException(status_code=404, detail="Service not found")
+    except HTTPException:
+        raise
     except Exception as e:
         raise HTTPException(status_code=500, detail=str(e))
 
+
 @router.post("/{service_id}/restart")
-async def restart_persistent_service(service_id: int, db: Session = Depends(get_db)):
+async def restart_persistent_service(
+    service_id: int,
+    db: Session = Depends(get_db),
+    user: User = Depends(current_user),
+):
     """Restart a persistent service."""
     try:
+        svc = _scoped(db, user).filter(PersistentService.id == service_id).first()
+        if not svc:
+            raise HTTPException(status_code=404, detail="Service not found")
         success = service_manager.restart_service(service_id, db)
         if success:
             return {"message": "Service restart initiated"}
-        else:
-            raise HTTPException(status_code=404, detail="Service not found")
+        raise HTTPException(status_code=404, detail="Service not found")
+    except HTTPException:
+        raise
     except Exception as e:
         raise HTTPException(status_code=500, detail=str(e))
 
+
 @router.get("/{service_id}/logs")
-async def get_service_logs(service_id: int, limit: int = 100, db: Session = Depends(get_db)):
+async def get_service_logs(
+    service_id: int,
+    limit: int = 100,
+    db: Session = Depends(get_db),
+    user: User = Depends(current_user),
+):
     """Get logs for a specific service."""
     try:
-        service = db.query(PersistentService).filter(PersistentService.id == service_id).first()
+        service = _scoped(db, user).filter(PersistentService.id == service_id).first()
         if not service:
             raise HTTPException(status_code=404, detail="Service not found")
         

--- a/routers/users.py
+++ b/routers/users.py
@@ -1,0 +1,261 @@
+"""User and API-key management.
+
+  /users/me/keys            — CRUD for the caller's own long-lived keys.
+  /admin/users              — admin-only CRUD for every user.
+
+Key plaintext is returned exactly once at creation (POST response) and
+never again. After that only the prefix is visible.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime
+from typing import List
+
+from fastapi import APIRouter, Depends, HTTPException, status
+from sqlalchemy.orm import Session
+
+from database import get_db
+from db_models import ApiKey, User, SYSTEM_USER_ID
+from models.schemas import (
+    ApiKeyCreateRequest,
+    ApiKeyCreateResponse,
+    ApiKeyResponse,
+    UserCreateRequest,
+    UserResponse,
+    UserUpdateRequest,
+)
+from auth import current_user, generate_token, hash_password, require_admin
+
+
+router = APIRouter(tags=["users"])
+
+
+def _user_response(user: User) -> UserResponse:
+    return UserResponse(
+        id=user.id,
+        email=user.email,
+        is_admin=bool(user.is_admin),
+        disabled=bool(user.disabled),
+        created_at=user.created_at.isoformat() if user.created_at else "",
+    )
+
+
+def _key_response(key: ApiKey) -> ApiKeyResponse:
+    return ApiKeyResponse(
+        id=key.id,
+        prefix=key.prefix,
+        label=key.label,
+        last_used_at=key.last_used_at.isoformat() if key.last_used_at else None,
+        created_at=key.created_at.isoformat() if key.created_at else "",
+    )
+
+
+# ---------------------------------------------------------------------
+# /users/me/keys — caller-owned API keys
+# ---------------------------------------------------------------------
+
+
+@router.get(
+    "/users/me/keys",
+    response_model=List[ApiKeyResponse],
+    summary="List the caller's API keys",
+)
+async def list_my_keys(
+    user: User = Depends(current_user),
+    db: Session = Depends(get_db),
+):
+    if user.id == SYSTEM_USER_ID:
+        # The system user exists as a backing identity for anonymous
+        # requests; its keys (if any) aren't meaningful to clients.
+        return []
+    keys = (
+        db.query(ApiKey)
+        .filter(
+            ApiKey.user_id == user.id,
+            ApiKey.kind == "api",
+            ApiKey.revoked_at.is_(None),
+        )
+        .order_by(ApiKey.created_at.desc())
+        .all()
+    )
+    return [_key_response(k) for k in keys]
+
+
+@router.post(
+    "/users/me/keys",
+    response_model=ApiKeyCreateResponse,
+    summary="Mint a new API key for the caller (plaintext returned once)",
+)
+async def create_my_key(
+    body: ApiKeyCreateRequest,
+    user: User = Depends(current_user),
+    db: Session = Depends(get_db),
+):
+    if user.id == SYSTEM_USER_ID:
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail="the system user cannot mint tokens — log in as a "
+                   "real user first",
+        )
+    plaintext, hashed, prefix = generate_token()
+    key = ApiKey(
+        user_id=user.id,
+        hashed_key=hashed,
+        prefix=prefix,
+        label=body.label,
+        kind="api",
+    )
+    db.add(key)
+    db.commit()
+    db.refresh(key)
+    return ApiKeyCreateResponse(
+        id=key.id,
+        token=plaintext,
+        prefix=prefix,
+        label=key.label,
+        created_at=key.created_at.isoformat() if key.created_at else "",
+    )
+
+
+@router.delete(
+    "/users/me/keys/{key_id}",
+    summary="Revoke one of the caller's API keys",
+)
+async def revoke_my_key(
+    key_id: int,
+    user: User = Depends(current_user),
+    db: Session = Depends(get_db),
+):
+    key = (
+        db.query(ApiKey)
+        .filter(ApiKey.id == key_id, ApiKey.user_id == user.id)
+        .first()
+    )
+    if key is None:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND, detail="key not found"
+        )
+    if key.revoked_at is None:
+        key.revoked_at = datetime.utcnow()
+        db.commit()
+    return {"ok": True}
+
+
+# ---------------------------------------------------------------------
+# /admin/users — admin-only CRUD for every user
+# ---------------------------------------------------------------------
+
+
+@router.get(
+    "/admin/users",
+    response_model=List[UserResponse],
+    summary="List all users (admin only)",
+)
+async def list_users(
+    _: User = Depends(require_admin),
+    db: Session = Depends(get_db),
+):
+    users = db.query(User).order_by(User.id.asc()).all()
+    return [_user_response(u) for u in users]
+
+
+@router.post(
+    "/admin/users",
+    response_model=UserResponse,
+    status_code=status.HTTP_201_CREATED,
+    summary="Create a new user (admin only)",
+)
+async def create_user(
+    body: UserCreateRequest,
+    _: User = Depends(require_admin),
+    db: Session = Depends(get_db),
+):
+    existing = db.query(User).filter(User.email == body.email).first()
+    if existing is not None:
+        raise HTTPException(
+            status_code=status.HTTP_409_CONFLICT,
+            detail="email already in use",
+        )
+    user = User(
+        email=body.email,
+        password_hash=hash_password(body.password),
+        is_admin=1 if body.is_admin else 0,
+        disabled=0,
+    )
+    db.add(user)
+    db.commit()
+    db.refresh(user)
+    return _user_response(user)
+
+
+@router.patch(
+    "/admin/users/{user_id}",
+    response_model=UserResponse,
+    summary="Update a user (admin only)",
+)
+async def update_user(
+    user_id: int,
+    body: UserUpdateRequest,
+    _: User = Depends(require_admin),
+    db: Session = Depends(get_db),
+):
+    if user_id == SYSTEM_USER_ID:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="cannot modify the system user",
+        )
+    user = db.query(User).filter(User.id == user_id).first()
+    if user is None:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND, detail="user not found"
+        )
+    if body.email is not None:
+        clash = db.query(User).filter(
+            User.email == body.email, User.id != user_id
+        ).first()
+        if clash is not None:
+            raise HTTPException(
+                status_code=status.HTTP_409_CONFLICT,
+                detail="email already in use",
+            )
+        user.email = body.email
+    if body.password:
+        user.password_hash = hash_password(body.password)
+    if body.is_admin is not None:
+        user.is_admin = 1 if body.is_admin else 0
+    if body.disabled is not None:
+        user.disabled = 1 if body.disabled else 0
+    db.commit()
+    db.refresh(user)
+    return _user_response(user)
+
+
+@router.delete(
+    "/admin/users/{user_id}",
+    summary="Delete a user (admin only). Revokes all their keys.",
+)
+async def delete_user(
+    user_id: int,
+    _: User = Depends(require_admin),
+    db: Session = Depends(get_db),
+):
+    if user_id == SYSTEM_USER_ID:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="cannot delete the system user",
+        )
+    user = db.query(User).filter(User.id == user_id).first()
+    if user is None:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND, detail="user not found"
+        )
+    # Revoke their keys rather than cascading deletes; preserves audit
+    # trail and keeps owner_user_id FKs on historical rows valid.
+    now = datetime.utcnow()
+    db.query(ApiKey).filter(
+        ApiKey.user_id == user_id, ApiKey.revoked_at.is_(None)
+    ).update({ApiKey.revoked_at: now})
+    db.delete(user)
+    db.commit()
+    return {"ok": True}

--- a/routers/webhook_execution.py
+++ b/routers/webhook_execution.py
@@ -4,7 +4,7 @@ import time
 import base64
 import json
 from datetime import datetime
-from models import WebhookJob, ExecutionLog
+from models import WebhookJob, ExecutionLog, SYSTEM_USER_ID
 from database import get_db
 from services.code_executor_service import get_code_executor
 from env_manager import EnvironmentManager
@@ -120,10 +120,12 @@ async def execute_webhook(path: str, request: Request, db: Session = Depends(get
         if job.packages and job.packages.strip():
             packages = [pkg.strip() for pkg in job.packages.split(",") if pkg.strip()]
 
-        # Environment variables: user's encrypted secrets + request data
-        # for non-Python languages.
+        owner_user_id = job.owner_user_id or SYSTEM_USER_ID
+
+        # Environment variables: owner's encrypted secrets + request
+        # data for non-Python languages.
         env_manager = get_env_manager()
-        env_vars = dict(env_manager.get_all_variables())
+        env_vars = dict(env_manager.get_all_variables(owner_user_id=owner_user_id))
         if language != "python":
             env_vars["SUPAKILN_REQUEST_DATA"] = request_data_json
 
@@ -136,6 +138,7 @@ async def execute_webhook(path: str, request: Request, db: Session = Depends(get
             timeout=timeout_s,
             env_vars=env_vars,
             language=language,
+            user_id=owner_user_id,
         )
 
         success = bool(exec_result.get("success"))
@@ -168,6 +171,7 @@ async def execute_webhook(path: str, request: Request, db: Session = Depends(get
         # Log the execution
         log = ExecutionLog(
             webhook_job_id=job.id,
+            owner_user_id=owner_user_id,
             code=job.code,
             output=json.dumps(response_data) if success else None,
             error=error_output if not success else None,
@@ -194,6 +198,7 @@ async def execute_webhook(path: str, request: Request, db: Session = Depends(get
         # Log the error
         log = ExecutionLog(
             webhook_job_id=job.id if 'job' in locals() else None,
+            owner_user_id=(job.owner_user_id if 'job' in locals() and job else SYSTEM_USER_ID),
             code=job.code if 'job' in locals() else "",
             error=str(e),
             execution_time=time.time() - start_time,

--- a/routers/webhook_execution.py
+++ b/routers/webhook_execution.py
@@ -6,16 +6,11 @@ import json
 from datetime import datetime
 from models import WebhookJob, ExecutionLog
 from database import get_db
-from services.docker_client import docker_client
-from code_executor import CodeExecutor
+from services.code_executor_service import get_code_executor
 from env_manager import EnvironmentManager
 import os
-import docker
 
 router = APIRouter(prefix="/webhook", tags=["webhook-execution"])
-
-# Initialize executor
-executor = CodeExecutor()
 
 def get_env_manager():
     """Get environment manager instance."""
@@ -83,141 +78,115 @@ async def execute_webhook(path: str, request: Request, db: Session = Depends(get
             "endpoint": endpoint
         }
         
-        # Prepare the code with request context
-        # Encode the request data safely using base64
-        request_data_encoded = base64.b64encode(json.dumps(request_data).encode()).decode()
-        
-        # The webhook code will have access to 'request_data' and should set 'response_data'
-        wrapper_code = f"""
-import json
-import sys
-import base64
-from datetime import datetime
+        # Resolve language (backfill to python for rows predating the
+        # `language` column).
+        language = (getattr(job, "language", None) or "python")
 
-# Request data available to the webhook code (safely decoded from base64)
-request_data = json.loads(base64.b64decode("{request_data_encoded}").decode())
-
-# Default response
-response_data = {{"message": "Webhook executed successfully", "timestamp": datetime.now().isoformat()}}
-
-# User's webhook code
-try:
-{chr(10).join("    " + line for line in job.code.split(chr(10)))}
-except Exception as e:
-    response_data = {{"error": str(e), "timestamp": datetime.now().isoformat()}}
-    print(f"Error in webhook code: {{e}}", file=sys.stderr)
-
-# Output the response (this will be captured and returned)
-print(json.dumps(response_data))
-"""
-        
-        # Execute the webhook code
-        if job.container_id:
-            # Use existing container
-            if job.container_id not in executor.containers.values():
-                raise HTTPException(status_code=500, detail="Webhook job container not found")
-            
-            container = docker_client.containers.get(job.container_id)
+        # Build the code that will run in the worker. For Python we keep
+        # the historical contract: user code sees a `request_data` local
+        # and writes back into `response_data`. For other languages, we
+        # pass request data as SUPAKILN_REQUEST_DATA (JSON) and the user
+        # code is responsible for parsing it + printing a JSON response
+        # to stdout.
+        request_data_json = json.dumps(request_data)
+        if language == "python":
+            request_data_b64 = base64.b64encode(request_data_json.encode()).decode()
+            wrapper_code = (
+                "import json\n"
+                "import sys\n"
+                "import base64\n"
+                "from datetime import datetime\n"
+                "\n"
+                f'request_data = json.loads(base64.b64decode("{request_data_b64}").decode())\n'
+                'response_data = {"message": "Webhook executed successfully", '
+                '"timestamp": datetime.now().isoformat()}\n'
+                "\n"
+                "try:\n"
+                + "\n".join("    " + line for line in job.code.split("\n"))
+                + "\n"
+                "except Exception as e:\n"
+                '    response_data = {"error": str(e), "timestamp": datetime.now().isoformat()}\n'
+                '    print(f"Error in webhook code: {e}", file=sys.stderr)\n'
+                "\n"
+                "print(json.dumps(response_data))\n"
+            )
+            code_to_run = wrapper_code
         else:
-            # Create/get container with packages
-            packages = []
-            if job.packages and job.packages.strip():
-                packages = [pkg.strip() for pkg in job.packages.split(',') if pkg.strip()]
-            
-            package_hash = executor._get_package_hash(packages)
-            image_tag = executor._build_image(packages)
-            
-            if package_hash not in executor.containers:
-                # Get network mode from environment variable (defaults to 'none' for security)
-                container_network_mode = os.environ.get('CONTAINER_NETWORK_MODE', 'none')
-                
-                container = docker_client.containers.run(
-                    image_tag,
-                    detach=True,
-                    tty=True,
-                    mem_limit="512m",
-                    cpu_period=100000,
-                    cpu_quota=50000,
-                    user="1000:1000",
-                    network_mode=container_network_mode,  # Configurable network mode
-                    cap_drop=["ALL"],  # Remove all capabilities
-                    pids_limit=100  # Limit number of processes (keep reasonable limit)
-                )
-                executor.containers[package_hash] = container.id
-            
-            container_id = executor.containers[package_hash]
-            container = docker_client.containers.get(container_id)
-        
-        # Get environment variables
+            # No auto-wrapping for non-Python; user emits JSON to stdout.
+            code_to_run = job.code
+
+        # Packages from the stored comma-separated string.
+        packages: list = []
+        if job.packages and job.packages.strip():
+            packages = [pkg.strip() for pkg in job.packages.split(",") if pkg.strip()]
+
+        # Environment variables: user's encrypted secrets + request data
+        # for non-Python languages.
         env_manager = get_env_manager()
-        env_vars = env_manager.get_all_variables()
-        
-        # Execute with timeout (support infinite timeout with -1)
-        encoded_code = base64.b64encode(wrapper_code.encode()).decode()
-        
-        if job.timeout == -1:
-            # Infinite timeout - no timeout command
-            exec_command = f"python -c 'import base64; exec(base64.b64decode(\"{encoded_code}\").decode())'"
-        else:
-            # Normal timeout
-            exec_command = f"timeout {job.timeout} python -c 'import base64; exec(base64.b64decode(\"{encoded_code}\").decode())'"
-        
-        result = container.exec_run(
-            exec_command,
-            environment=env_vars
+        env_vars = dict(env_manager.get_all_variables())
+        if language != "python":
+            env_vars["SUPAKILN_REQUEST_DATA"] = request_data_json
+
+        # -1 means "no timeout"; treat as a very large number of seconds.
+        timeout_s = 60 * 60 * 24 if job.timeout == -1 else int(job.timeout)
+
+        exec_result = get_code_executor().execute_code(
+            code=code_to_run,
+            packages=packages,
+            timeout=timeout_s,
+            env_vars=env_vars,
+            language=language,
         )
-        
-        # Parse the output
-        success = result.exit_code == 0
-        output = result.output.decode() if result.output else ""
-        
-        # Try to parse the response data from output
+
+        success = bool(exec_result.get("success"))
+        output = (exec_result.get("output") or "")
+        error_output = exec_result.get("error") or ""
+        container_id = exec_result.get("container_id")
+
+        # Parse the last JSON-shaped line of stdout as the response body.
         response_data = None
-        if success and output.strip():
-            try:
-                # The last line should be the JSON response
-                lines = output.strip().split('\n')
-                for line in reversed(lines):
-                    line = line.strip()
-                    if line.startswith('{') and line.endswith('}'):
+        if output.strip():
+            for line in reversed(output.strip().splitlines()):
+                line = line.strip()
+                if line.startswith("{") and line.endswith("}"):
+                    try:
                         response_data = json.loads(line)
                         break
-            except Exception as e:
-                print(f"Error parsing webhook response: {e}")
-                response_data = {"output": output}
-        
-        if not response_data:
+                    except json.JSONDecodeError:
+                        continue
+        if response_data is None:
             response_data = {
                 "success": success,
-                "output": output if success else None,
-                "error": output if not success else None
+                "output": output or None,
+                "error": error_output or None,
             }
-        
+
         # Update job last triggered time
         job.last_triggered = datetime.utcnow()
         db.commit()
-        
+
         # Log the execution
         log = ExecutionLog(
             webhook_job_id=job.id,
             code=job.code,
             output=json.dumps(response_data) if success else None,
-            error=output if not success else None,
-            container_id=container.id,
+            error=error_output if not success else None,
+            container_id=container_id,
             execution_time=time.time() - start_time,
             started_at=datetime.utcnow(),
             status="success" if success else "error",
-            request_data=json.dumps(request_data),
-            response_data=json.dumps(response_data) if success else None
+            request_data=request_data_json,
+            response_data=json.dumps(response_data) if success else None,
         )
         db.add(log)
         db.commit()
-        
-        # Return the response
+
         if success:
             return response_data
-        else:
-            raise HTTPException(status_code=500, detail=response_data.get("error", "Webhook execution failed"))
+        raise HTTPException(
+            status_code=500,
+            detail=response_data.get("error") or error_output or "Webhook execution failed",
+        )
             
     except HTTPException:
         raise

--- a/routers/webhooks.py
+++ b/routers/webhooks.py
@@ -3,8 +3,9 @@ from sqlalchemy.orm import Session
 from typing import List
 from datetime import datetime
 from models.schemas import WebhookJobRequest, WebhookJobResponse
-from models import WebhookJob
+from models import WebhookJob, User
 from database import get_db
+from auth import current_user
 import languages as lang_registry
 
 router = APIRouter(prefix="/webhook-jobs", tags=["webhook-jobs"])
@@ -38,14 +39,27 @@ def _job_to_response(job: WebhookJob) -> dict:
         "language": getattr(job, "language", None) or "python",
     }
 
+
+def _scoped(db: Session, user: User):
+    q = db.query(WebhookJob)
+    if not user.is_admin:
+        q = q.filter(WebhookJob.owner_user_id == user.id)
+    return q
+
+
 @router.post("", response_model=WebhookJobResponse)
-async def create_webhook_job(request: WebhookJobRequest, db: Session = Depends(get_db)):
+async def create_webhook_job(
+    request: WebhookJobRequest,
+    db: Session = Depends(get_db),
+    user: User = Depends(current_user),
+):
     """Create a new webhook job."""
     language = _validate_language(request.language)
     try:
         if not request.endpoint.startswith('/'):
             request.endpoint = '/' + request.endpoint
 
+        # endpoint is GLOBAL-unique by design — URL routing needs it.
         existing = db.query(WebhookJob).filter(WebhookJob.endpoint == request.endpoint).first()
         if existing:
             raise HTTPException(status_code=400, detail="Endpoint already exists")
@@ -61,6 +75,7 @@ async def create_webhook_job(request: WebhookJobRequest, db: Session = Depends(g
             language=language,
             created_at=datetime.now(),
             is_active=True,
+            owner_user_id=user.id,
         )
         db.add(db_job)
         db.commit()
@@ -74,27 +89,39 @@ async def create_webhook_job(request: WebhookJobRequest, db: Session = Depends(g
 
 
 @router.get("", response_model=List[WebhookJobResponse])
-async def list_webhook_jobs(db: Session = Depends(get_db)):
-    """List all webhook jobs."""
-    jobs = db.query(WebhookJob).all()
+async def list_webhook_jobs(
+    db: Session = Depends(get_db),
+    user: User = Depends(current_user),
+):
+    """List webhook jobs owned by the caller (admins see all)."""
+    jobs = _scoped(db, user).all()
     return [_job_to_response(job) for job in jobs]
 
 
 @router.get("/{job_id}", response_model=WebhookJobResponse)
-async def get_webhook_job(job_id: int, db: Session = Depends(get_db)):
+async def get_webhook_job(
+    job_id: int,
+    db: Session = Depends(get_db),
+    user: User = Depends(current_user),
+):
     """Get a specific webhook job."""
-    job = db.query(WebhookJob).filter(WebhookJob.id == job_id).first()
+    job = _scoped(db, user).filter(WebhookJob.id == job_id).first()
     if not job:
         raise HTTPException(status_code=404, detail="Webhook job not found")
     return _job_to_response(job)
 
 
 @router.put("/{job_id}", response_model=WebhookJobResponse)
-async def update_webhook_job(job_id: int, request: WebhookJobRequest, db: Session = Depends(get_db)):
+async def update_webhook_job(
+    job_id: int,
+    request: WebhookJobRequest,
+    db: Session = Depends(get_db),
+    user: User = Depends(current_user),
+):
     """Update a webhook job."""
     language = _validate_language(request.language)
     try:
-        job = db.query(WebhookJob).filter(WebhookJob.id == job_id).first()
+        job = _scoped(db, user).filter(WebhookJob.id == job_id).first()
         if not job:
             raise HTTPException(status_code=404, detail="Webhook job not found")
 
@@ -126,19 +153,22 @@ async def update_webhook_job(job_id: int, request: WebhookJobRequest, db: Sessio
         db.rollback()
         raise HTTPException(status_code=500, detail=str(e))
 
+
 @router.delete("/{job_id}")
-async def delete_webhook_job(job_id: int, db: Session = Depends(get_db)):
+async def delete_webhook_job(
+    job_id: int,
+    db: Session = Depends(get_db),
+    user: User = Depends(current_user),
+):
     """Delete a webhook job."""
     try:
-        job = db.query(WebhookJob).filter(WebhookJob.id == job_id).first()
+        job = _scoped(db, user).filter(WebhookJob.id == job_id).first()
         if not job:
             raise HTTPException(status_code=404, detail="Webhook job not found")
-        
+
         db.delete(job)
         db.commit()
         return {"message": "Webhook job deleted successfully"}
     except Exception as e:
         db.rollback()
         raise HTTPException(status_code=500, detail=str(e))
-
- 

--- a/routers/webhooks.py
+++ b/routers/webhooks.py
@@ -1,112 +1,28 @@
-from fastapi import APIRouter, HTTPException, Depends, Request
+from fastapi import APIRouter, HTTPException, Depends
 from sqlalchemy.orm import Session
 from typing import List
-import time
-import base64
-import json
 from datetime import datetime
 from models.schemas import WebhookJobRequest, WebhookJobResponse
-from models import WebhookJob, ExecutionLog
+from models import WebhookJob
 from database import get_db
-from services.docker_client import docker_client
-from code_executor import CodeExecutor
-from env_manager import EnvironmentManager
-import os
+import languages as lang_registry
 
 router = APIRouter(prefix="/webhook-jobs", tags=["webhook-jobs"])
 
-# Initialize executor
-executor = CodeExecutor()
 
-def get_env_manager():
-    """Get environment manager instance."""
-    from models import SessionLocal
-    db = SessionLocal()
+def _validate_language(name):
+    if name is None:
+        return "python"
     try:
-        # Try to load existing key
-        if os.path.exists('.env_key'):
-            with open('.env_key', 'rb') as key_file:
-                key = key_file.read()
-        else:
-            key = None
-        env_manager = EnvironmentManager(db, key)
-        return env_manager
-    finally:
-        db.close()
-
-@router.post("", response_model=WebhookJobResponse)
-async def create_webhook_job(request: WebhookJobRequest, db: Session = Depends(get_db)):
-    """Create a new webhook job."""
-    try:
-        # Validate endpoint format
-        if not request.endpoint.startswith('/'):
-            request.endpoint = '/' + request.endpoint
-        
-        # Check if endpoint already exists
-        existing = db.query(WebhookJob).filter(WebhookJob.endpoint == request.endpoint).first()
-        if existing:
-            raise HTTPException(status_code=400, detail="Endpoint already exists")
-        
-        # Create job in database
-        db_job = WebhookJob(
-            name=request.name,
-            endpoint=request.endpoint,
-            code=request.code,
-            packages=','.join(request.packages) if request.packages else None,
-            container_id=request.container_id,
-            timeout=request.timeout,
-            description=request.description,
-            created_at=datetime.now(),
-            is_active=True
+        return lang_registry.get(name).name
+    except KeyError:
+        raise HTTPException(
+            status_code=400,
+            detail=f"unknown language {name!r}; known: {lang_registry.names()}",
         )
-        db.add(db_job)
-        db.commit()
-        db.refresh(db_job)
-        
-        return {
-            "id": db_job.id,
-            "name": db_job.name,
-            "endpoint": db_job.endpoint,
-            "code": db_job.code,
-            "packages": db_job.packages,
-            "container_id": db_job.container_id,
-            "created_at": db_job.created_at.isoformat(),
-            "last_triggered": db_job.last_triggered.isoformat() if db_job.last_triggered else None,
-            "is_active": db_job.is_active,
-            "timeout": db_job.timeout,
-            "description": db_job.description
-        }
-    except Exception as e:
-        db.rollback()
-        raise HTTPException(status_code=500, detail=str(e))
 
-@router.get("", response_model=List[WebhookJobResponse])
-async def list_webhook_jobs(db: Session = Depends(get_db)):
-    """List all webhook jobs."""
-    jobs = db.query(WebhookJob).all()
-    return [
-        {
-            "id": job.id,
-            "name": job.name,
-            "endpoint": job.endpoint,
-            "code": job.code,
-            "packages": job.packages,
-            "container_id": job.container_id,
-            "created_at": job.created_at.isoformat(),
-            "last_triggered": job.last_triggered.isoformat() if job.last_triggered else None,
-            "is_active": job.is_active,
-            "timeout": job.timeout,
-            "description": job.description
-        }
-        for job in jobs
-    ]
 
-@router.get("/{job_id}", response_model=WebhookJobResponse)
-async def get_webhook_job(job_id: int, db: Session = Depends(get_db)):
-    """Get a specific webhook job."""
-    job = db.query(WebhookJob).filter(WebhookJob.id == job_id).first()
-    if not job:
-        raise HTTPException(status_code=404, detail="Webhook job not found")
+def _job_to_response(job: WebhookJob) -> dict:
     return {
         "id": job.id,
         "name": job.name,
@@ -116,32 +32,82 @@ async def get_webhook_job(job_id: int, db: Session = Depends(get_db)):
         "container_id": job.container_id,
         "created_at": job.created_at.isoformat(),
         "last_triggered": job.last_triggered.isoformat() if job.last_triggered else None,
-        "is_active": job.is_active,
+        "is_active": bool(job.is_active),
         "timeout": job.timeout,
-        "description": job.description
+        "description": job.description,
+        "language": getattr(job, "language", None) or "python",
     }
+
+@router.post("", response_model=WebhookJobResponse)
+async def create_webhook_job(request: WebhookJobRequest, db: Session = Depends(get_db)):
+    """Create a new webhook job."""
+    language = _validate_language(request.language)
+    try:
+        if not request.endpoint.startswith('/'):
+            request.endpoint = '/' + request.endpoint
+
+        existing = db.query(WebhookJob).filter(WebhookJob.endpoint == request.endpoint).first()
+        if existing:
+            raise HTTPException(status_code=400, detail="Endpoint already exists")
+
+        db_job = WebhookJob(
+            name=request.name,
+            endpoint=request.endpoint,
+            code=request.code,
+            packages=','.join(request.packages) if request.packages else None,
+            container_id=request.container_id,
+            timeout=request.timeout,
+            description=request.description,
+            language=language,
+            created_at=datetime.now(),
+            is_active=True,
+        )
+        db.add(db_job)
+        db.commit()
+        db.refresh(db_job)
+        return _job_to_response(db_job)
+    except HTTPException:
+        raise
+    except Exception as e:
+        db.rollback()
+        raise HTTPException(status_code=500, detail=str(e))
+
+
+@router.get("", response_model=List[WebhookJobResponse])
+async def list_webhook_jobs(db: Session = Depends(get_db)):
+    """List all webhook jobs."""
+    jobs = db.query(WebhookJob).all()
+    return [_job_to_response(job) for job in jobs]
+
+
+@router.get("/{job_id}", response_model=WebhookJobResponse)
+async def get_webhook_job(job_id: int, db: Session = Depends(get_db)):
+    """Get a specific webhook job."""
+    job = db.query(WebhookJob).filter(WebhookJob.id == job_id).first()
+    if not job:
+        raise HTTPException(status_code=404, detail="Webhook job not found")
+    return _job_to_response(job)
+
 
 @router.put("/{job_id}", response_model=WebhookJobResponse)
 async def update_webhook_job(job_id: int, request: WebhookJobRequest, db: Session = Depends(get_db)):
     """Update a webhook job."""
+    language = _validate_language(request.language)
     try:
         job = db.query(WebhookJob).filter(WebhookJob.id == job_id).first()
         if not job:
             raise HTTPException(status_code=404, detail="Webhook job not found")
-        
-        # Validate endpoint format
+
         if not request.endpoint.startswith('/'):
             request.endpoint = '/' + request.endpoint
-        
-        # Check if endpoint already exists (excluding current job)
+
         existing = db.query(WebhookJob).filter(
             WebhookJob.endpoint == request.endpoint,
-            WebhookJob.id != job_id
+            WebhookJob.id != job_id,
         ).first()
         if existing:
             raise HTTPException(status_code=400, detail="Endpoint already exists")
-        
-        # Update job
+
         job.name = request.name
         job.endpoint = request.endpoint
         job.code = request.code
@@ -149,23 +115,13 @@ async def update_webhook_job(job_id: int, request: WebhookJobRequest, db: Sessio
         job.container_id = request.container_id
         job.timeout = request.timeout
         job.description = request.description
-        
+        job.language = language
+
         db.commit()
         db.refresh(job)
-        
-        return {
-            "id": job.id,
-            "name": job.name,
-            "endpoint": job.endpoint,
-            "code": job.code,
-            "packages": job.packages,
-            "container_id": job.container_id,
-            "created_at": job.created_at.isoformat(),
-            "last_triggered": job.last_triggered.isoformat() if job.last_triggered else None,
-            "is_active": job.is_active,
-            "timeout": job.timeout,
-            "description": job.description
-        }
+        return _job_to_response(job)
+    except HTTPException:
+        raise
     except Exception as e:
         db.rollback()
         raise HTTPException(status_code=500, detail=str(e))

--- a/routers/workers.py
+++ b/routers/workers.py
@@ -1,10 +1,10 @@
 """Lifecycle API for ad-hoc worker containers.
 
-The executor caches one worker container per (language, package_hash) so
-subsequent /execute calls reuse a live HTTP server instead of spawning
-fresh docker exec sessions. These endpoints let a dev inspect, kill, or
-reset those workers — useful for clearing state during development or
-when a container is misbehaving.
+The executor caches one worker container per (language, user_id,
+package_hash) so subsequent /execute calls reuse a live HTTP server
+instead of spawning fresh docker exec sessions. These endpoints let a
+user inspect, kill, or reset their own workers (admins can see + touch
+anyone's).
 """
 
 from __future__ import annotations
@@ -12,9 +12,11 @@ from __future__ import annotations
 from datetime import datetime, timezone
 from typing import Dict, List, Optional
 
-from fastapi import APIRouter, HTTPException
+from fastapi import APIRouter, Depends, HTTPException
 
+from db_models import User
 from services.code_executor_service import get_code_executor
+from auth import current_user
 
 
 router = APIRouter(prefix="/workers", tags=["workers"])
@@ -32,6 +34,7 @@ def _format_worker(w: Dict) -> Dict:
         "language": w["language"],
         "package_hash": w["package_hash"],
         "cache_key": w["cache_key"],
+        "user_id": w.get("user_id"),
         "host": w.get("host"),
         "port": w.get("port"),
         "created_at": _iso(w.get("created_at")),
@@ -40,56 +43,76 @@ def _format_worker(w: Dict) -> Dict:
 
 
 @router.get("", summary="List live ad-hoc workers")
-async def list_workers() -> Dict[str, List[Dict]]:
-    """Return a snapshot of every worker container currently cached.
+async def list_workers(
+    user: User = Depends(current_user),
+) -> Dict[str, List[Dict]]:
+    """Return a snapshot of worker containers the caller owns.
 
-    Each entry: `container_id`, `container_short_id` (12-char),
-    `language`, `package_hash`, `cache_key`, `host`, `port`,
-    `created_at` (ISO), `last_used` (ISO). The idle reaper uses
-    `last_used` vs. `SUPAKILN_WORKER_IDLE_TTL_SECONDS` to decide what
-    to kill; this list shows you the live state between reaps.
+    Admins see every worker; non-admins only see their own.
     """
-    workers = get_code_executor().list_workers()
+    scope = None if user.is_admin else user.id
+    workers = get_code_executor().list_workers(user_id=scope)
     return {"workers": [_format_worker(w) for w in workers]}
 
 
 @router.delete("/{container_id}", summary="Stop one worker")
-async def stop_worker(container_id: str) -> Dict[str, object]:
+async def stop_worker(
+    container_id: str,
+    user: User = Depends(current_user),
+) -> Dict[str, object]:
     """Force-kill a tracked worker and evict its cache entry.
 
-    Accepts either a 12-character short ID (as returned from `GET /workers`
-    or `POST /execute`) or a full 64-character container ID. If the ID
-    prefix matches multiple live workers, returns 400. If the container
-    isn't tracked, returns 404 — though it still best-effort removes
-    the container in case it's a stale one the executor lost track of
-    after a restart.
+    Accepts either a 12-character short ID or a full 64-character
+    container ID. If the ID prefix matches multiple live workers,
+    returns 400. Non-admins can only stop containers they own.
     """
     executor = get_code_executor()
-    # Resolve a short ID to the full one if needed.
+    # Resolve a short ID to the full one if needed, scoped to what the
+    # caller is allowed to see.
     if len(container_id) < 64:
         matches = [
-            cid for cid in executor.worker_meta
+            cid for cid, meta in executor.worker_meta.items()
             if cid.startswith(container_id)
+            and (user.is_admin or meta.get("user_id") == user.id)
         ]
         if len(matches) == 1:
             container_id = matches[0]
         elif len(matches) > 1:
             raise HTTPException(status_code=400, detail="ambiguous container id prefix")
+        else:
+            raise HTTPException(status_code=404, detail="worker not tracked")
 
-    existed = executor.stop_worker(container_id)
-    if not existed:
-        # stop_worker still tried to remove an untracked container; surface
-        # a 404 so callers know it wasn't in our cache.
+    meta = executor.worker_meta.get(container_id)
+    if meta is None:
         raise HTTPException(status_code=404, detail="worker not tracked")
+    if not user.is_admin and meta.get("user_id") != user.id:
+        raise HTTPException(status_code=404, detail="worker not tracked")
+
+    executor.stop_worker(container_id)
     return {"stopped": container_id}
 
 
-@router.post("/reset", summary="Stop every ad-hoc worker")
-async def reset_workers() -> Dict[str, int]:
-    """Kill every cached ad-hoc worker container.
+@router.post("/reset", summary="Stop every ad-hoc worker the caller owns")
+async def reset_workers(
+    user: User = Depends(current_user),
+) -> Dict[str, int]:
+    """Kill the caller's cached workers. Admins kill everyone's.
 
     Does not touch persistent-service containers (those have their own
     lifecycle under `/services`). Response: `{"killed": N}`.
     """
-    killed = get_code_executor().reset_workers()
+    executor = get_code_executor()
+    if user.is_admin:
+        killed = executor.reset_workers()
+    else:
+        # Reap only the caller's workers.
+        targets = [
+            (cid, meta["cache_key"])
+            for cid, meta in list(executor.worker_meta.items())
+            if meta.get("user_id") == user.id
+        ]
+        killed = 0
+        for cid, cache_key in targets:
+            executor._evict_worker(cache_key, cid)
+            killed += 1
     return {"killed": killed}

--- a/routers/workers.py
+++ b/routers/workers.py
@@ -1,0 +1,76 @@
+"""Lifecycle API for ad-hoc worker containers.
+
+The executor caches one worker container per (language, package_hash) so
+subsequent /execute calls reuse a live HTTP server instead of spawning
+fresh docker exec sessions. These endpoints let a dev inspect, kill, or
+reset those workers — useful for clearing state during development or
+when a container is misbehaving.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from typing import Dict, List, Optional
+
+from fastapi import APIRouter, HTTPException
+
+from services.code_executor_service import get_code_executor
+
+
+router = APIRouter(prefix="/workers", tags=["workers"])
+
+
+def _format_worker(w: Dict) -> Dict:
+    def _iso(ts: Optional[float]) -> Optional[str]:
+        if ts is None:
+            return None
+        return datetime.fromtimestamp(ts, tz=timezone.utc).isoformat()
+
+    return {
+        "container_id": w["container_id"],
+        "container_short_id": w["container_id"][:12],
+        "language": w["language"],
+        "package_hash": w["package_hash"],
+        "cache_key": w["cache_key"],
+        "host": w.get("host"),
+        "port": w.get("port"),
+        "created_at": _iso(w.get("created_at")),
+        "last_used": _iso(w.get("last_used")),
+    }
+
+
+@router.get("")
+async def list_workers() -> Dict[str, List[Dict]]:
+    """Snapshot of live ad-hoc workers."""
+    workers = get_code_executor().list_workers()
+    return {"workers": [_format_worker(w) for w in workers]}
+
+
+@router.delete("/{container_id}")
+async def stop_worker(container_id: str) -> Dict[str, object]:
+    """Force-kill a specific worker. Accepts short (12-char) or full ID."""
+    executor = get_code_executor()
+    # Resolve a short ID to the full one if needed.
+    if len(container_id) < 64:
+        matches = [
+            cid for cid in executor.worker_meta
+            if cid.startswith(container_id)
+        ]
+        if len(matches) == 1:
+            container_id = matches[0]
+        elif len(matches) > 1:
+            raise HTTPException(status_code=400, detail="ambiguous container id prefix")
+
+    existed = executor.stop_worker(container_id)
+    if not existed:
+        # stop_worker still tried to remove an untracked container; surface
+        # a 404 so callers know it wasn't in our cache.
+        raise HTTPException(status_code=404, detail="worker not tracked")
+    return {"stopped": container_id}
+
+
+@router.post("/reset")
+async def reset_workers() -> Dict[str, int]:
+    """Kill every ad-hoc worker (does not touch web-service containers)."""
+    killed = get_code_executor().reset_workers()
+    return {"killed": killed}

--- a/routers/workers.py
+++ b/routers/workers.py
@@ -39,16 +39,31 @@ def _format_worker(w: Dict) -> Dict:
     }
 
 
-@router.get("")
+@router.get("", summary="List live ad-hoc workers")
 async def list_workers() -> Dict[str, List[Dict]]:
-    """Snapshot of live ad-hoc workers."""
+    """Return a snapshot of every worker container currently cached.
+
+    Each entry: `container_id`, `container_short_id` (12-char),
+    `language`, `package_hash`, `cache_key`, `host`, `port`,
+    `created_at` (ISO), `last_used` (ISO). The idle reaper uses
+    `last_used` vs. `SUPAKILN_WORKER_IDLE_TTL_SECONDS` to decide what
+    to kill; this list shows you the live state between reaps.
+    """
     workers = get_code_executor().list_workers()
     return {"workers": [_format_worker(w) for w in workers]}
 
 
-@router.delete("/{container_id}")
+@router.delete("/{container_id}", summary="Stop one worker")
 async def stop_worker(container_id: str) -> Dict[str, object]:
-    """Force-kill a specific worker. Accepts short (12-char) or full ID."""
+    """Force-kill a tracked worker and evict its cache entry.
+
+    Accepts either a 12-character short ID (as returned from `GET /workers`
+    or `POST /execute`) or a full 64-character container ID. If the ID
+    prefix matches multiple live workers, returns 400. If the container
+    isn't tracked, returns 404 — though it still best-effort removes
+    the container in case it's a stale one the executor lost track of
+    after a restart.
+    """
     executor = get_code_executor()
     # Resolve a short ID to the full one if needed.
     if len(container_id) < 64:
@@ -69,8 +84,12 @@ async def stop_worker(container_id: str) -> Dict[str, object]:
     return {"stopped": container_id}
 
 
-@router.post("/reset")
+@router.post("/reset", summary="Stop every ad-hoc worker")
 async def reset_workers() -> Dict[str, int]:
-    """Kill every ad-hoc worker (does not touch web-service containers)."""
+    """Kill every cached ad-hoc worker container.
+
+    Does not touch persistent-service containers (those have their own
+    lifecycle under `/services`). Response: `{"killed": N}`.
+    """
     killed = get_code_executor().reset_workers()
     return {"killed": killed}

--- a/scheduler.py
+++ b/scheduler.py
@@ -22,6 +22,7 @@ class JobScheduler:
         if not self._initialized:
             self.load_existing_jobs()
             self._schedule_cleanup_job()
+            self._schedule_worker_reaper()
             self._initialized = True
 
     def _schedule_cleanup_job(self):
@@ -41,6 +42,50 @@ class JobScheduler:
             replace_existing=True,
         )
         logger.info("Scheduled periodic cleanup job (every 6 hours)")
+
+    def _schedule_worker_reaper(self):
+        """Periodically kill ad-hoc workers that have been idle too long.
+
+        Configured by two env vars:
+          SUPAKILN_WORKER_IDLE_TTL_SECONDS  reap threshold; <=0 disables.
+                                            Default 1800 (30 minutes).
+          SUPAKILN_WORKER_REAPER_INTERVAL_SECONDS  how often to scan.
+                                                   Default 60.
+        """
+        import os
+        from services.code_executor_service import get_code_executor
+
+        try:
+            idle_ttl = float(os.environ.get("SUPAKILN_WORKER_IDLE_TTL_SECONDS", "1800"))
+        except ValueError:
+            idle_ttl = 1800
+        try:
+            interval = float(os.environ.get("SUPAKILN_WORKER_REAPER_INTERVAL_SECONDS", "60"))
+        except ValueError:
+            interval = 60
+
+        if idle_ttl <= 0:
+            logger.info("Worker idle reaper disabled (SUPAKILN_WORKER_IDLE_TTL_SECONDS <= 0)")
+            return
+
+        def _reap_wrapper():
+            try:
+                reaped = get_code_executor().reap_idle_workers(idle_ttl)
+                if reaped:
+                    logger.info("Reaped %d idle worker(s): %s", len(reaped), reaped)
+            except Exception:
+                logger.exception("Worker reaper failed")
+
+        self.scheduler.add_job(
+            _reap_wrapper,
+            IntervalTrigger(seconds=interval),
+            id="__worker_reaper",
+            replace_existing=True,
+        )
+        logger.info(
+            "Scheduled worker idle reaper (ttl=%.0fs, interval=%.0fs)",
+            idle_ttl, interval,
+        )
 
     def load_existing_jobs(self):
         """Load all active jobs from the database and schedule them."""

--- a/scheduler.py
+++ b/scheduler.py
@@ -84,7 +84,8 @@ class JobScheduler:
                 result = self.executor.execute_code(
                     code=job.code,
                     packages=job.packages.split(',') if job.packages else [],
-                    timeout=getattr(job, 'timeout', 30)  # Use job timeout or default to 30
+                    timeout=getattr(job, 'timeout', 30),
+                    language=getattr(job, 'language', None) or 'python',
                 )
                 
                 execution_time = time.time() - start_time
@@ -121,7 +122,7 @@ class JobScheduler:
         finally:
             db.close()
 
-    def add_job(self, name, code, cron_expression, container_id=None, packages=None):
+    def add_job(self, name, code, cron_expression, container_id=None, packages=None, language="python", timeout=30):
         """Add a new scheduled job."""
         db = SessionLocal()
         try:
@@ -130,12 +131,14 @@ class JobScheduler:
                 code=code,
                 cron_expression=cron_expression,
                 container_id=container_id,
-                packages=','.join(packages) if packages else None
+                packages=','.join(packages) if packages else None,
+                language=language or "python",
+                timeout=timeout,
             )
             db.add(job)
             db.commit()
             db.refresh(job)
-            
+
             self.schedule_job(job)
             return job
         finally:

--- a/scheduler.py
+++ b/scheduler.py
@@ -4,7 +4,7 @@ from apscheduler.triggers.interval import IntervalTrigger
 from datetime import datetime
 import time
 import logging
-from models import SessionLocal, ScheduledJob, ExecutionLog
+from models import SessionLocal, ScheduledJob, ExecutionLog, SYSTEM_USER_ID
 from code_executor import CodeExecutor
 
 logger = logging.getLogger(__name__)
@@ -23,6 +23,7 @@ class JobScheduler:
             self.load_existing_jobs()
             self._schedule_cleanup_job()
             self._schedule_worker_reaper()
+            self._schedule_pressure_reaper()
             self._initialized = True
 
     def _schedule_cleanup_job(self):
@@ -87,6 +88,65 @@ class JobScheduler:
             idle_ttl, interval,
         )
 
+    def _schedule_pressure_reaper(self):
+        """Periodically evict idle workers when the host is under load.
+
+        Memory pressure uses /proc/meminfo; CPU pressure uses
+        /proc/loadavg. Both are host-wide (container /proc reflects the
+        host's view under Docker). Two-threshold eviction with a high
+        and low water avoids thrashing. Configured by:
+
+          SUPAKILN_PRESSURE_REAPER_INTERVAL_SECONDS  scan cadence
+                                                     (default 30)
+          SUPAKILN_MEMORY_HIGH_WATER_PCT             memory trigger
+          SUPAKILN_MEMORY_LOW_WATER_PCT              memory stop
+          SUPAKILN_CPU_HIGH_WATER                    load_1m trigger
+        """
+        import os
+        from services.code_executor_service import get_code_executor
+
+        try:
+            interval = float(
+                os.environ.get("SUPAKILN_PRESSURE_REAPER_INTERVAL_SECONDS", "30")
+            )
+        except ValueError:
+            interval = 30.0
+
+        if interval <= 0:
+            logger.info(
+                "Pressure reaper disabled "
+                "(SUPAKILN_PRESSURE_REAPER_INTERVAL_SECONDS <= 0)"
+            )
+            return
+
+        def _pressure_wrapper():
+            try:
+                exec_ = get_code_executor()
+                mem_reaped = exec_.reap_memory_pressure()
+                if mem_reaped:
+                    logger.warning(
+                        "Memory-pressure reaped %d worker(s): %s",
+                        len(mem_reaped), mem_reaped,
+                    )
+                cpu_reaped = exec_.reap_cpu_pressure()
+                if cpu_reaped:
+                    logger.warning(
+                        "CPU-pressure reaped %d worker(s): %s",
+                        len(cpu_reaped), cpu_reaped,
+                    )
+            except Exception:
+                logger.exception("Pressure reaper failed")
+
+        self.scheduler.add_job(
+            _pressure_wrapper,
+            IntervalTrigger(seconds=interval),
+            id="__pressure_reaper",
+            replace_existing=True,
+        )
+        logger.info(
+            "Scheduled pressure reaper (interval=%.0fs)", interval,
+        )
+
     def load_existing_jobs(self):
         """Load all active jobs from the database and schedule them."""
         db = SessionLocal()
@@ -115,7 +175,12 @@ class JobScheduler:
         )
 
     async def execute_job(self, job_id):
-        """Execute a scheduled job and log its results."""
+        """Execute a scheduled job and log its results.
+
+        The job runs in its owner's worker container, and the owner's
+        encrypted env vars are injected. The system user runs
+        owner-less jobs (legacy rows).
+        """
         db = SessionLocal()
         try:
             job = db.query(ScheduledJob).filter(ScheduledJob.id == job_id).first()
@@ -123,7 +188,20 @@ class JobScheduler:
                 return
 
             start_time = time.time()
-            
+            owner_user_id = job.owner_user_id or SYSTEM_USER_ID
+
+            # Pull the owner's env vars. Imported lazily to avoid a
+            # circular import at module load time.
+            from env_manager import EnvironmentManager
+            import os
+            key = None
+            if os.path.exists('.env_key'):
+                with open('.env_key', 'rb') as f:
+                    key = f.read()
+            env_vars = EnvironmentManager(db, key).get_all_variables(
+                owner_user_id=owner_user_id
+            )
+
             # Execute the code
             try:
                 result = self.executor.execute_code(
@@ -131,13 +209,16 @@ class JobScheduler:
                     packages=job.packages.split(',') if job.packages else [],
                     timeout=getattr(job, 'timeout', 30),
                     language=getattr(job, 'language', None) or 'python',
+                    env_vars=env_vars,
+                    user_id=owner_user_id,
                 )
-                
+
                 execution_time = time.time() - start_time
-                
+
                 # Log the execution
                 log = ExecutionLog(
                     job_id=job.id,
+                    owner_user_id=owner_user_id,
                     code=job.code,
                     output=result.get('output'),
                     error=result.get('error'),
@@ -145,15 +226,16 @@ class JobScheduler:
                     execution_time=execution_time,
                     status='success' if result.get('success') else 'error'
                 )
-                
+
                 db.add(log)
                 job.last_run = datetime.utcnow()
                 db.commit()
-                
+
             except Exception as e:
                 execution_time = time.time() - start_time
                 log = ExecutionLog(
                     job_id=job.id,
+                    owner_user_id=owner_user_id,
                     code=job.code,
                     error=str(e),
                     container_id=None,
@@ -163,11 +245,21 @@ class JobScheduler:
                 db.add(log)
                 job.last_run = datetime.utcnow()
                 db.commit()
-                
+
         finally:
             db.close()
 
-    def add_job(self, name, code, cron_expression, container_id=None, packages=None, language="python", timeout=30):
+    def add_job(
+        self,
+        name,
+        code,
+        cron_expression,
+        container_id=None,
+        packages=None,
+        language="python",
+        timeout=30,
+        owner_user_id=SYSTEM_USER_ID,
+    ):
         """Add a new scheduled job."""
         db = SessionLocal()
         try:
@@ -179,6 +271,7 @@ class JobScheduler:
                 packages=','.join(packages) if packages else None,
                 language=language or "python",
                 timeout=timeout,
+                owner_user_id=owner_user_id,
             )
             db.add(job)
             db.commit()

--- a/services/service_manager.py
+++ b/services/service_manager.py
@@ -136,8 +136,10 @@ class ServiceManager:
                 container_id = executor.containers[package_hash]
                 service.container_id = container_id
             
-            # Get environment variables
-            from models import SessionLocal
+            # Get environment variables scoped to the service's owner
+            # (legacy rows without an owner fall back to the system user).
+            from models import SessionLocal, SYSTEM_USER_ID
+            owner_user_id = service.owner_user_id or SYSTEM_USER_ID
             env_db = SessionLocal()
             try:
                 # Try to load existing key
@@ -147,7 +149,7 @@ class ServiceManager:
                 else:
                     key = None
                 env_manager = EnvironmentManager(env_db, key)
-                env_vars = env_manager.get_all_variables()
+                env_vars = env_manager.get_all_variables(owner_user_id=owner_user_id)
             finally:
                 env_db.close()
             

--- a/workers/python/worker.py
+++ b/workers/python/worker.py
@@ -1,0 +1,139 @@
+"""Supakiln Python worker.
+
+Long-running HTTP server inside each python-runtime container. Receives
+code-execution requests over TCP, runs them as subprocesses, and returns
+stdout / stderr / exit_code. Exists to bypass `docker exec` on the hot path
+(~75ms namespace-entry cost) — the backend reaches us directly over the
+dind bridge network instead.
+
+Wire contract:
+  GET  /health  -> 200 "ok"
+  POST /exec    -> body: {"code": str, "env": {str: str}, "timeout_ms": int}
+                  resp: {"exit_code": int, "stdout": str, "stderr": str, "timed_out": bool}
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import sys
+import tempfile
+import threading
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+from typing import Tuple
+
+
+DEFAULT_PORT = 9999
+MAX_BODY_BYTES = 10 * 1024 * 1024  # 10 MiB guard against runaway payloads
+
+
+def _run_code(code: str, env: dict, timeout_ms: int) -> dict:
+    """Write code to a temp .py and exec it with a clean subprocess."""
+    timeout_s = max(0.001, timeout_ms / 1000.0)
+    # Use /tmp inside the container (tmpfs-friendly, always writable).
+    with tempfile.NamedTemporaryFile(
+        mode="w", suffix=".py", delete=False, dir="/tmp", encoding="utf-8"
+    ) as f:
+        f.write(code)
+        fname = f.name
+
+    proc_env = os.environ.copy()
+    # Caller-supplied env vars win over inherited ones.
+    proc_env.update({str(k): str(v) for k, v in (env or {}).items()})
+
+    try:
+        result = subprocess.run(
+            [sys.executable, fname],
+            capture_output=True,
+            text=True,
+            timeout=timeout_s,
+            env=proc_env,
+        )
+        return {
+            "exit_code": result.returncode,
+            "stdout": result.stdout or "",
+            "stderr": result.stderr or "",
+            "timed_out": False,
+        }
+    except subprocess.TimeoutExpired as e:
+        return {
+            "exit_code": -1,
+            "stdout": (e.stdout.decode() if isinstance(e.stdout, bytes) else (e.stdout or "")),
+            "stderr": (e.stderr.decode() if isinstance(e.stderr, bytes) else (e.stderr or ""))
+                     + f"\n--- Execution timed out after {timeout_s:.3f}s ---",
+            "timed_out": True,
+        }
+    finally:
+        try:
+            os.remove(fname)
+        except OSError:
+            pass
+
+
+class Handler(BaseHTTPRequestHandler):
+    # Silence default access logging — the backend already logs executions.
+    def log_message(self, *args, **kwargs) -> None:
+        return
+
+    def _json(self, status: int, payload: dict) -> None:
+        body = json.dumps(payload).encode("utf-8")
+        self.send_response(status)
+        self.send_header("Content-Type", "application/json")
+        self.send_header("Content-Length", str(len(body)))
+        self.end_headers()
+        self.wfile.write(body)
+
+    def do_GET(self) -> None:
+        if self.path == "/health":
+            self._json(200, {"status": "ok"})
+        else:
+            self._json(404, {"error": "not found"})
+
+    def do_POST(self) -> None:
+        if self.path != "/exec":
+            self._json(404, {"error": "not found"})
+            return
+        try:
+            length = int(self.headers.get("Content-Length", "0"))
+        except ValueError:
+            self._json(400, {"error": "invalid content-length"})
+            return
+        if length <= 0 or length > MAX_BODY_BYTES:
+            self._json(400, {"error": "invalid body size"})
+            return
+
+        raw = self.rfile.read(length)
+        try:
+            req = json.loads(raw.decode("utf-8"))
+        except (UnicodeDecodeError, json.JSONDecodeError) as e:
+            self._json(400, {"error": f"invalid json: {e}"})
+            return
+
+        code = req.get("code")
+        if not isinstance(code, str):
+            self._json(400, {"error": "`code` must be a string"})
+            return
+        env = req.get("env") or {}
+        if not isinstance(env, dict):
+            self._json(400, {"error": "`env` must be an object"})
+            return
+        timeout_ms = int(req.get("timeout_ms", 30000))
+
+        result = _run_code(code, env, timeout_ms)
+        self._json(200, result)
+
+
+def main() -> None:
+    port = int(os.environ.get("SUPAKILN_WORKER_PORT", DEFAULT_PORT))
+    bind = os.environ.get("SUPAKILN_WORKER_BIND", "0.0.0.0")
+    server = ThreadingHTTPServer((bind, port), Handler)
+    print(f"[supakiln-worker] listening on {bind}:{port}", flush=True)
+    try:
+        server.serve_forever()
+    except KeyboardInterrupt:
+        server.shutdown()
+
+
+if __name__ == "__main__":
+    main()

--- a/workers/worker.py
+++ b/workers/worker.py
@@ -1,13 +1,24 @@
-"""Supakiln Python worker.
+"""Supakiln multi-language worker.
 
-Long-running HTTP server inside each python-runtime container. Receives
-code-execution requests over TCP, runs them as subprocesses, and returns
-stdout / stderr / exit_code. Exists to bypass `docker exec` on the hot path
-(~75ms namespace-entry cost) — the backend reaches us directly over the
-dind bridge network instead.
+Long-running HTTP server inside each runtime container. Receives
+code-execution requests over TCP, writes the submitted code to a temp
+file, then spawns the language-specific interpreter/compiler as a
+subprocess. Exists to bypass `docker exec` on the hot path (~75ms
+namespace-entry cost) — the backend reaches us directly over the dind
+bridge network instead.
+
+The worker is language-agnostic: it is configured per-image via env vars.
+
+  SUPAKILN_RUN_CMD   shell command template; {file} is replaced with the
+                     path to the temp source file. Example:
+                       "python3 {file}"   "node {file}"   "bash {file}"
+                       "go run {file}"    "ruby {file}"
+  SUPAKILN_FILE_EXT  suffix for the temp file (".py", ".js", ".rb", ...).
+                     Some interpreters (e.g. go run) need a correct ext.
+  SUPAKILN_WORKER_PORT, SUPAKILN_WORKER_BIND   listen config.
 
 Wire contract:
-  GET  /health  -> 200 "ok"
+  GET  /health  -> 200 {"status": "ok"}
   POST /exec    -> body: {"code": str, "env": {str: str}, "timeout_ms": int}
                   resp: {"exit_code": int, "stdout": str, "stderr": str, "timed_out": bool}
 """
@@ -16,24 +27,31 @@ from __future__ import annotations
 
 import json
 import os
+import shlex
 import subprocess
-import sys
 import tempfile
-import threading
 from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
-from typing import Tuple
 
 
 DEFAULT_PORT = 9999
 MAX_BODY_BYTES = 10 * 1024 * 1024  # 10 MiB guard against runaway payloads
 
+RUN_CMD_TEMPLATE = os.environ.get("SUPAKILN_RUN_CMD", "python3 {file}")
+FILE_EXT = os.environ.get("SUPAKILN_FILE_EXT", ".py")
+
+
+def _build_command(file_path: str) -> list:
+    """Render RUN_CMD_TEMPLATE by substituting {file}, respecting shell splitting."""
+    parts = shlex.split(RUN_CMD_TEMPLATE)
+    return [p.replace("{file}", file_path) for p in parts]
+
 
 def _run_code(code: str, env: dict, timeout_ms: int) -> dict:
-    """Write code to a temp .py and exec it with a clean subprocess."""
+    """Write code to a temp file and exec it via RUN_CMD_TEMPLATE."""
     timeout_s = max(0.001, timeout_ms / 1000.0)
     # Use /tmp inside the container (tmpfs-friendly, always writable).
     with tempfile.NamedTemporaryFile(
-        mode="w", suffix=".py", delete=False, dir="/tmp", encoding="utf-8"
+        mode="w", suffix=FILE_EXT, delete=False, dir="/tmp", encoding="utf-8"
     ) as f:
         f.write(code)
         fname = f.name
@@ -44,11 +62,12 @@ def _run_code(code: str, env: dict, timeout_ms: int) -> dict:
 
     try:
         result = subprocess.run(
-            [sys.executable, fname],
+            _build_command(fname),
             capture_output=True,
             text=True,
             timeout=timeout_s,
             env=proc_env,
+            cwd="/tmp",
         )
         return {
             "exit_code": result.returncode,

--- a/workers/worker.py
+++ b/workers/worker.py
@@ -16,18 +16,24 @@ The worker is language-agnostic: it is configured per-image via env vars.
   SUPAKILN_FILE_EXT  suffix for the temp file (".py", ".js", ".rb", ...).
                      Some interpreters (e.g. go run) need a correct ext.
   SUPAKILN_WORKER_PORT, SUPAKILN_WORKER_BIND   listen config.
+  SUPAKILN_WORKER_TOKEN  required bearer secret; caller must send it as
+                         `X-Supakiln-Token`. Blocks sibling containers
+                         (no auth previously → cross-worker RCE).
 
 Wire contract:
-  GET  /health  -> 200 {"status": "ok"}
+  GET  /health  -> 200 {"status": "ok"}      (unauthenticated)
   POST /exec    -> body: {"code": str, "env": {str: str}, "timeout_ms": int}
+                  headers: X-Supakiln-Token: <secret>
                   resp: {"exit_code": int, "stdout": str, "stderr": str, "timed_out": bool}
 """
 
 from __future__ import annotations
 
+import hmac
 import json
 import os
 import shlex
+import signal
 import subprocess
 import tempfile
 from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
@@ -38,12 +44,75 @@ MAX_BODY_BYTES = 10 * 1024 * 1024  # 10 MiB guard against runaway payloads
 
 RUN_CMD_TEMPLATE = os.environ.get("SUPAKILN_RUN_CMD", "python3 {file}")
 FILE_EXT = os.environ.get("SUPAKILN_FILE_EXT", ".py")
+# Set by the backend at `docker run` time. If empty, /exec is wide open
+# (dev-only fallback). In production the backend always sets it.
+EXPECTED_TOKEN = os.environ.get("SUPAKILN_WORKER_TOKEN", "")
 
 
 def _build_command(file_path: str) -> list:
     """Render RUN_CMD_TEMPLATE by substituting {file}, respecting shell splitting."""
     parts = shlex.split(RUN_CMD_TEMPLATE)
     return [p.replace("{file}", file_path) for p in parts]
+
+
+def _reap_leftover_state(own_pid: int, own_script_path: str | None) -> None:
+    """Kill straggler processes and wipe scratch dirs between /exec calls.
+
+    Runs in the worker's finally after every execution — successful,
+    failed, or timed out. We own uid 1000; the worker process is pid 1
+    inside its container (or very close to it). Everything else owned
+    by this uid is user code that may have forked, backgrounded, or
+    otherwise outlived the request. Kill it so state never leaks into
+    the next call.
+
+    Scratch wipe also bounds tmpfs usage: a misbehaving run can't fill
+    /tmp permanently because the next call clears it.
+    """
+    # 1) Kill every uid-1000 process except us.
+    try:
+        for entry in os.listdir("/proc"):
+            if not entry.isdigit():
+                continue
+            pid = int(entry)
+            if pid == own_pid:
+                continue
+            try:
+                with open(f"/proc/{pid}/status", "r") as f:
+                    body = f.read()
+                # "Uid:\treal\teffective\tsaved\tfs"
+                for line in body.splitlines():
+                    if line.startswith("Uid:"):
+                        parts = line.split()
+                        if len(parts) >= 2 and parts[1] == str(os.getuid()):
+                            try:
+                                os.kill(pid, signal.SIGKILL)
+                            except (ProcessLookupError, PermissionError):
+                                pass
+                        break
+            except (OSError, ValueError):
+                continue
+    except OSError:
+        pass
+
+    # 2) Wipe /tmp and /home/codeuser. Keep the directories themselves
+    # (tmpfs mount points must exist). Don't delete the script path if
+    # we haven't removed it yet — the caller handles it.
+    for root in ("/tmp", "/home/codeuser"):
+        try:
+            for name in os.listdir(root):
+                path = os.path.join(root, name)
+                if path == own_script_path:
+                    continue
+                try:
+                    if os.path.isdir(path) and not os.path.islink(path):
+                        import shutil
+                        shutil.rmtree(path, ignore_errors=True)
+                    else:
+                        os.unlink(path)
+                except OSError:
+                    pass
+        except OSError:
+            pass
 
 
 def _run_code(code: str, env: dict, timeout_ms: int) -> dict:
@@ -57,37 +126,66 @@ def _run_code(code: str, env: dict, timeout_ms: int) -> dict:
         fname = f.name
 
     proc_env = os.environ.copy()
-    # Caller-supplied env vars win over inherited ones.
+    # Caller-supplied env vars win over inherited ones. Strip the worker
+    # token from the child's env — user code has no business reading it.
+    proc_env.pop("SUPAKILN_WORKER_TOKEN", None)
     proc_env.update({str(k): str(v) for k, v in (env or {}).items()})
 
+    proc: subprocess.Popen | None = None
     try:
-        result = subprocess.run(
+        # start_new_session makes the child the leader of a new process
+        # group. On timeout / normal exit we kill the whole group via
+        # killpg, which catches `cmd &` background subprocesses that
+        # `subprocess.run`'s plain kill would otherwise leak.
+        proc = subprocess.Popen(
             _build_command(fname),
-            capture_output=True,
-            text=True,
-            timeout=timeout_s,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
             env=proc_env,
             cwd="/tmp",
+            start_new_session=True,
         )
-        return {
-            "exit_code": result.returncode,
-            "stdout": result.stdout or "",
-            "stderr": result.stderr or "",
-            "timed_out": False,
-        }
-    except subprocess.TimeoutExpired as e:
-        return {
-            "exit_code": -1,
-            "stdout": (e.stdout.decode() if isinstance(e.stdout, bytes) else (e.stdout or "")),
-            "stderr": (e.stderr.decode() if isinstance(e.stderr, bytes) else (e.stderr or ""))
-                     + f"\n--- Execution timed out after {timeout_s:.3f}s ---",
-            "timed_out": True,
-        }
+        try:
+            stdout, stderr = proc.communicate(timeout=timeout_s)
+            return {
+                "exit_code": proc.returncode,
+                "stdout": (stdout or b"").decode("utf-8", "replace"),
+                "stderr": (stderr or b"").decode("utf-8", "replace"),
+                "timed_out": False,
+            }
+        except subprocess.TimeoutExpired:
+            try:
+                os.killpg(os.getpgid(proc.pid), signal.SIGKILL)
+            except (ProcessLookupError, PermissionError):
+                pass
+            # Drain whatever the child emitted before we killed it.
+            try:
+                stdout, stderr = proc.communicate(timeout=2.0)
+            except subprocess.TimeoutExpired:
+                proc.kill()
+                stdout, stderr = proc.communicate()
+            return {
+                "exit_code": -1,
+                "stdout": (stdout or b"").decode("utf-8", "replace"),
+                "stderr": (stderr or b"").decode("utf-8", "replace")
+                         + f"\n--- Execution timed out after {timeout_s:.3f}s ---",
+                "timed_out": True,
+            }
     finally:
+        # Make sure the process group is gone even on success; user code
+        # may have forked daemons that we need to reap.
+        if proc is not None:
+            try:
+                os.killpg(os.getpgid(proc.pid), signal.SIGKILL)
+            except (ProcessLookupError, PermissionError):
+                pass
         try:
             os.remove(fname)
         except OSError:
             pass
+        # Final scrub: kill lingering uid-1000 processes the user may
+        # have nohup'd outside the process group, and wipe scratch dirs.
+        _reap_leftover_state(own_pid=os.getpid(), own_script_path=None)
 
 
 class Handler(BaseHTTPRequestHandler):
@@ -113,6 +211,16 @@ class Handler(BaseHTTPRequestHandler):
         if self.path != "/exec":
             self._json(404, {"error": "not found"})
             return
+
+        # Bearer-token check. Constant-time compare to avoid exposing
+        # the token through timing differences. When EXPECTED_TOKEN is
+        # empty (legacy/dev) we skip the check.
+        if EXPECTED_TOKEN:
+            supplied = self.headers.get("X-Supakiln-Token", "")
+            if not hmac.compare_digest(supplied, EXPECTED_TOKEN):
+                self._json(401, {"error": "invalid or missing token"})
+                return
+
         try:
             length = int(self.headers.get("Content-Length", "0"))
         except ValueError:


### PR DESCRIPTION
## Summary

Lands 13 commits on `main`. Biggest change in the project's history; groups naturally into five tracks.

### 1. Multi-language execution (10 commits, pre-existing on `docs/api-metadata`)

- **Runtime abstraction**: new `languages/` registry; each language is a `Runtime` dataclass (`name`, `base_image_tag`, `dockerfile_path`, `package_install_cmd_template`, `file_extension`, …).
- **In-container HTTP worker** (`workers/worker.py`): long-running server that bypasses `docker exec` on the hot path. Cold-start ≈ 200–500 ms, warm-path `/exec` ≈ 3 ms.
- **Supported runtimes**: Python (pip), Node 20 (npm), Ruby (gem), Bash, Go (stdlib). Per-language Dockerfile under `dockerfiles/`.
- **`language` plumbed through** scheduled jobs and webhook jobs end-to-end (schema, scheduler, webhook execution wrapper, frontend).
- **Worker lifecycle API**: `GET /workers`, `DELETE /workers/{id}`, `POST /workers/reset`, plus an idle reaper (`SUPAKILN_WORKER_IDLE_TTL_SECONDS`).
- **Self-heal**: if a cached worker is unreachable, the executor evicts + rebuilds + retries once before surfacing an error.
- **Frontend**: language picker in editor, template gallery per runtime, Workers page.
- **OpenAPI metadata overhaul**: tag descriptions, per-endpoint `summary`/`description`, request-body examples.

### 2. Multi-tenant auth (this session)

- **Schema v9**: `users` (email, argon2 password hash, is_admin, disabled) + `api_keys` (sha256 of plaintext, prefix for display, kind ∈ {api, session}). The `system` user (id=1) is the anonymous-fallback identity.
- **Endpoints**: `/auth/{login,logout,me}`, `/users/me/keys` (caller-owned), `/admin/users` (admin-only CRUD).
- **`SUPAKILN_ALLOW_ANONYMOUS`** (default `true`) — transition switch. Unauthenticated requests attribute to the system user so existing clients keep working; flip to `false` to require auth on every call.
- **`SUPAKILN_BOOTSTRAP_ADMIN_EMAIL/_PASSWORD`** create the first admin on startup when no admin exists.

### 3. Per-user worker isolation (this session)

- **Schema v10**: `owner_user_id` FK on every user-owned table (env vars, scheduled jobs, webhook jobs, persistent services, execution logs). `environment_variables` UNIQUE moved from `name` to `(owner_user_id, name)`.
- **Cache key changed**: `"{lang}:u{user_id}:{pkg_hash}"`. Each tenant gets their own worker container for a given (language, packages) — cross-user `/tmp`, PID, and env leaks stop existing.
- **`EnvironmentManager`** scoped by owner; only the caller's encrypted secrets are injected into their container.
- **All CRUD routers** filter by owner for non-admins; admins see everything. Scheduler + webhook exec + service manager run under the row's `owner_user_id`.

### 4. Caps + pressure eviction (this session)

- **`SUPAKILN_MAX_WORKERS_PER_USER`** (default 5) + **`SUPAKILN_MAX_WORKERS`** (default 50). Exceeding triggers LRU eviction of an idle worker; if all in-flight, `/execute` returns **429** (per-user) or **503** (global).
- **`busy_count`** tracks in-flight calls per container — eviction never picks a worker mid-call.
- **Background pressure reaper** reads host `/proc/meminfo` + `/proc/loadavg`, evicts LRU idle when either exceeds its high water. Two-threshold to avoid thrash. Tunable: `SUPAKILN_MEMORY_{HIGH,LOW}_WATER_PCT`, `SUPAKILN_CPU_HIGH_WATER`, `SUPAKILN_PRESSURE_REAPER_INTERVAL_SECONDS`.
- **Threadpool dispatch**: `/execute` was `async def` calling blocking sync code, serialising all requests on one event loop. Now wrapped with `run_in_threadpool` so concurrent requests actually run in parallel — without this the cap would never fire.

### 5. Worker hardening (this session)

Closes every finding from the earlier security probe.

- **Per-container bearer secret** (`secrets.token_urlsafe(32)`) minted at `docker run`, passed as `SUPAKILN_WORKER_TOKEN` env, enforced on `/exec` via `X-Supakiln-Token` header with `hmac.compare_digest`. Closes the cross-worker pivot (sibling container → `/exec` → RCE). Token is stripped from the user subprocess's env.
- **`--security-opt=no-new-privileges`** — SUID escalation blocked.
- **`--read-only`** rootfs; writes go only to explicit tmpfs mounts.
- **`--tmpfs /home/codeuser:size=16m`** — resettable `$HOME`, no more `.bashrc` persistence.
- **`start_new_session=True` + `killpg`** on timeout and in `finally`. Detached children (`nohup cmd & disown`) no longer outlive the request.
- **Post-call cleanup** in the worker: walks `/proc`, SIGKILLs every uid-1000 process except itself, wipes `/tmp` and `/home/codeuser`. The "plant a while-true daemon" class of attack no longer works.

### 6. Frontend auth UI (this session)

- **`/login`** page; axios interceptor attaches `Authorization: Bearer ...` from localStorage; 401s dispatch `supakiln:unauthorized` event → `AuthGuard` routes to `/login`.
- **`/keys`** page: list caller's keys (prefix + last-used), mint with copy-to-clipboard plaintext dialog shown exactly once.
- **`/admin/users`** page (admin-only): table + toggles for admin/enabled, reset-password dialog, delete confirmation. System user and self-actions locked.
- **Layout chip**: `anonymous` (outlined) / `email` (filled, primary for user, secondary for admin) with sign-in / logout control.
- **CORS fix**: Starlette's default `allow_origins=["*"]` + `allow_credentials=True` makes Chrome reject the response. Replaced with explicit `ALLOWED_ORIGINS` env + localhost defaults + `allow_origin_regex` for dev loopback.

### 7. Bench / test artifacts

- `bench/secprobe.sh`, `bench/run_probe.sh` — authenticated bash probe helpers.
- `bench/e2e_auth_caps.sh` — full regression: login, API-key CRUD, admin 403, per-user container isolation, env-var isolation, cap + LRU + 429 branches, pressure reaper registration.

## Test plan

- [x] `bench/e2e_auth_caps.sh` — all checks pass under default caps.
- [x] Same with `SUPAKILN_MAX_WORKERS_PER_USER=2` — the 429-when-all-busy branch also passes.
- [x] `bench/run_probe.sh` — `NoNewPrivs=1`, rootfs `ro`, `su` blocked, home tmpfs, daemon planted one call is gone the next, sibling `/exec` without token → 401.
- [x] Frontend build contains `/auth/login`, `/users/me/keys`, `/admin/users`, AuthProvider.
- [x] `SUPAKILN_ALLOW_ANONYMOUS=false` → anonymous endpoints return 401; frontend redirects to `/login`; post-login works.
- [x] `SUPAKILN_ALLOW_ANONYMOUS=true` (default) → existing clients unchanged; AppBar shows `anonymous` chip.

## Migrations

Two SQL schema bumps: **v8 → v9** creates `users` + `api_keys`, adds `owner_user_id` to all user-owned tables (defaulted to system user = 1). **v9 → v10** adds `owner_user_id` to `execution_logs` and rebuilds `environment_variables` with a composite `UNIQUE(owner_user_id, name)` so two users can have the same var name. Both run automatically on startup.

## Deferred

- `--icc=false` custom bridge network. Bearer auth already closes the pivot; this is belt-and-suspenders, can add later.
- Token-rotation UI / session revocation list.

🤖 Generated with [Claude Code](https://claude.com/claude-code)