### PR TITLE
Fix Go runtime: restore HOME dirs + exec on tmpfs, preserve caches

### DIFF
--- a/code_executor.py
+++ b/code_executor.py
@@ -26,6 +26,10 @@ APP_LABEL = "managed-by=supakiln"
 # Default tmpfs size for the worker container's /tmp. Caps how much
 # scratch space user code can consume inside a single container.
 DEFAULT_TMPFS_SIZE = os.environ.get("SUPAKILN_CONTAINER_TMPFS_SIZE", "128m")
+# /home/codeuser is a separate tmpfs that backs runtime caches
+# (Go compile cache, pip/npm caches, …). Sized larger than /tmp
+# because Go alone needs tens of MB for its stdlib archive cache.
+DEFAULT_HOME_TMPFS_SIZE = os.environ.get("SUPAKILN_HOME_TMPFS_SIZE", "256m")
 
 
 class WorkerUnreachableError(Exception):
@@ -772,9 +776,19 @@ USER codeuser
                 # scratch work; override with SUPAKILN_CONTAINER_TMPFS_SIZE.
                 "--tmpfs", f"/tmp:size={DEFAULT_TMPFS_SIZE},mode=1777",
                 # Writable home, also tmpfs so it resets with the
-                # container. Keeps install-free languages (bash, go)
-                # working when they want a writable $HOME.
-                "--tmpfs", "/home/codeuser:size=16m,mode=0755,uid=1000,gid=1000",
+                # container. Sized large enough for Go's stdlib
+                # archive cache + typical pip/npm caches; the per-call
+                # cleanup explicitly does NOT wipe /home so these
+                # caches persist across calls.
+                #
+                # `exec` is required because `go run` compiles the user
+                # program into $GOTMPDIR and then exec()s the binary —
+                # our /tmp stays noexec (default) to block arbitrary
+                # binary execution from scratch, but /home/codeuser is
+                # a real runtime cache dir so it needs exec.
+                "--tmpfs",
+                f"/home/codeuser:exec,size={DEFAULT_HOME_TMPFS_SIZE},"
+                f"mode=0755,uid=1000,gid=1000",
                 "-e", f"SUPAKILN_WORKER_TOKEN={worker_token}",
                 "-p", str(runtime.worker_port),  # publish to random host port on dind
                 image_tag,

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -63,6 +63,7 @@ services:
       - SUPAKILN_WORKER_IDLE_TTL_SECONDS=${SUPAKILN_WORKER_IDLE_TTL_SECONDS:-1800}
       - SUPAKILN_WORKER_REAPER_INTERVAL_SECONDS=${SUPAKILN_WORKER_REAPER_INTERVAL_SECONDS:-60}
       - SUPAKILN_CONTAINER_TMPFS_SIZE=${SUPAKILN_CONTAINER_TMPFS_SIZE:-128m}
+      - SUPAKILN_HOME_TMPFS_SIZE=${SUPAKILN_HOME_TMPFS_SIZE:-256m}
       # Caps. MAX_WORKERS is the global ceiling; MAX_WORKERS_PER_USER
       # keeps one tenant from monopolising. Exceeding a cap triggers
       # synchronous LRU eviction of an idle worker; if none are idle,

--- a/workers/worker.py
+++ b/workers/worker.py
@@ -94,25 +94,28 @@ def _reap_leftover_state(own_pid: int, own_script_path: str | None) -> None:
     except OSError:
         pass
 
-    # 2) Wipe /tmp and /home/codeuser. Keep the directories themselves
-    # (tmpfs mount points must exist). Don't delete the script path if
-    # we haven't removed it yet — the caller handles it.
-    for root in ("/tmp", "/home/codeuser"):
-        try:
-            for name in os.listdir(root):
-                path = os.path.join(root, name)
-                if path == own_script_path:
-                    continue
-                try:
-                    if os.path.isdir(path) and not os.path.islink(path):
-                        import shutil
-                        shutil.rmtree(path, ignore_errors=True)
-                    else:
-                        os.unlink(path)
-                except OSError:
-                    pass
-        except OSError:
-            pass
+    # 2) Wipe /tmp between calls. /home/codeuser is intentionally NOT
+    # wiped: runtimes (Go, npm, pip) keep their compile/module caches
+    # there and resetting them would turn every call into a cold
+    # build. Cross-call state isolation is about processes (handled by
+    # the pkill above) and scratch files (/tmp); /home is already a
+    # fresh tmpfs at container start, so any persistence is bounded
+    # by the idle-TTL restart anyway.
+    try:
+        for name in os.listdir("/tmp"):
+            path = os.path.join("/tmp", name)
+            if path == own_script_path:
+                continue
+            try:
+                if os.path.isdir(path) and not os.path.islink(path):
+                    import shutil
+                    shutil.rmtree(path, ignore_errors=True)
+                else:
+                    os.unlink(path)
+            except OSError:
+                pass
+    except OSError:
+        pass
 
 
 def _run_code(code: str, env: dict, timeout_ms: int) -> dict:
@@ -251,7 +254,34 @@ class Handler(BaseHTTPRequestHandler):
         self._json(200, result)
 
 
+def _ensure_runtime_dirs() -> None:
+    """Recreate directories runtimes expect under $HOME.
+
+    The Dockerfile `mkdir`s these at build time, but we mount
+    /home/codeuser as a fresh tmpfs at `docker run` — the tmpfs
+    replaces the image's home contents with an empty filesystem, so
+    `GOCACHE`/`GOPATH`/`GOTMPDIR` vanish on every container start.
+    Recreate anything pointed to by a well-known env var here, before
+    user code tries to use it.
+    """
+    candidates = [
+        os.environ.get("GOCACHE"),
+        os.environ.get("GOPATH"),
+        os.environ.get("GOTMPDIR"),
+        os.environ.get("npm_config_cache"),
+        os.environ.get("PIP_CACHE_DIR"),
+    ]
+    for d in candidates:
+        if not d:
+            continue
+        try:
+            os.makedirs(d, exist_ok=True)
+        except OSError as e:
+            print(f"[supakiln-worker] could not create {d}: {e}", flush=True)
+
+
 def main() -> None:
+    _ensure_runtime_dirs()
     port = int(os.environ.get("SUPAKILN_WORKER_PORT", DEFAULT_PORT))
     bind = os.environ.get("SUPAKILN_WORKER_BIND", "0.0.0.0")
     server = ThreadingHTTPServer((bind, port), Handler)


### PR DESCRIPTION
The security hardening added `--tmpfs /home/codeuser:size=16m` to reset HOME between container restarts, plus a per-call wipe of /home/codeuser alongside /tmp. This broke Go three ways:

1. Go's Dockerfile mkdir's `/home/codeuser/.gotmp`, `GOCACHE`, and `GOPATH` at build time. The tmpfs mount replaces the image's HOME with an empty filesystem, so those dirs don't exist at run time: go: creating work dir: stat /home/codeuser/.gotmp: no such file or directory Fix: `_ensure_runtime_dirs()` at worker startup mkdirs anything pointed to by GOCACHE / GOPATH / GOTMPDIR / npm_config_cache / PIP_CACHE_DIR. Runs before the HTTP server comes up, so the first /exec already sees the dirs.

2. Docker's `--tmpfs` defaults to `noexec`. `go run` compiles the user program into $GOTMPDIR and then exec()s the resulting binary — with noexec that fails with "fork/exec ... permission denied". Fix: mount /home/codeuser with `exec` so Go's compiled output can run. /tmp remains noexec (Docker default) so user code can't stash and execute arbitrary binaries out of scratch space.

3. The per-call cleanup wiped /home/codeuser, which would nuke Go's compile cache (and npm/pip caches) after every call — turning every /execute into a cold build. Fix: scope the cleanup to /tmp only. Cross-call isolation is still enforced by (a) pkill of every uid-1000 process except the worker, and (b) the /home tmpfs resetting on container restart bounded by the idle TTL.

Also bump the HOME tmpfs size from 16m to 256m — Go's stdlib archive cache alone approaches 100MB for a simple `go run hello.go`. Now tunable via `SUPAKILN_HOME_TMPFS_SIZE`.

Verified end-to-end:
  cold  go run -> 13.1s (full image build + compile)
  warm  go run -> 231ms (compile cache preserved)
  bash  unchanged
  /tmp  cp sh + run -> "Permission denied" (noexec intact)
  e2e_auth_caps.sh: all checks passed