### PR TITLE
Re-ensure runtime cache dirs per /exec

### DIFF
--- a/workers/worker.py
+++ b/workers/worker.py
@@ -227,6 +227,14 @@ def _run_code(code: str, env: dict, timeout_ms: int) -> dict:
 
     Raises WorkerCookedError if the container is resource-exhausted.
     """
+    # Re-ensure runtime cache dirs exist. They're created at worker
+    # startup but live on a tmpfs that user code can write into; a prior
+    # call may have filled the tmpfs (triggering ENOSPC cascades that
+    # delete siblings) or explicitly `rm -rf`'d part of $HOME. makedirs
+    # with exist_ok is idempotent and ~microseconds, so pay it on every
+    # call rather than debugging "go: creating work dir" errors later.
+    _ensure_runtime_dirs()
+
     timeout_s = max(0.001, timeout_ms / 1000.0)
     fname: str | None = None
     # Use /tmp inside the container (tmpfs-friendly, always writable).


### PR DESCRIPTION
## Summary
Follow-up to #8. `_ensure_runtime_dirs` ran once at worker startup to recreate `GOCACHE` / `GOPATH` / `GOTMPDIR` / npm / pip caches after the `/home/codeuser` tmpfs mount wiped them. That's enough when the container has just started, but the dirs live on a tmpfs user code can write into — a previous call can fill it (ENOSPC cascades deleting siblings), or user code can explicitly `rm -rf` part of `$HOME`. Once gone, the *next* Go call on the still-cached container fails with `go: creating work dir: stat /home/codeuser/.gotmp: no such file or directory` even though the worker process is healthy.

Move the call into `_run_code` so it runs per `/exec`. `makedirs(exist_ok=True)` is idempotent and ~microseconds.

## Test plan
- [x] Baseline Go call passes
- [x] Manually `rm -rf /home/codeuser/.gotmp` inside the cached container
- [x] Next Go call passes (would have failed before this change)

🤖 Generated with [Claude Code](https://claude.com/claude-code)